### PR TITLE
Adopt the upstreamed robot description and data-derived frames

### DIFF
--- a/docs/development/custom_callbacks_publishers.md
+++ b/docs/development/custom_callbacks_publishers.md
@@ -27,8 +27,8 @@ Publishing (output):
 ### Concrete Example: Controller Data Flow
 
 1. **Input**: `sensor_msgs/LaserScan` arrives on `/scan` topic.
-2. **Callback**: `LaserScanCallback` converts it to `kompass_core.datatypes.LaserScanData`.
-3. **Algorithm**: DWA controller reads `LaserScanData` along with `RobotState` (from odometry) and a reference `Path`.
+2. **Callback**: `LaserScanCallback` converts it to `ros_sugar.io.LaserScanData`.
+3. **Algorithm**: the Controller component hands the scan's `ranges` and `angles` to the DWA controller, along with `RobotState` (from odometry) and a reference `Path`.
 4. **Output**: DWA computes velocity commands; `Twist.convert(vx, vy, omega)` creates `geometry_msgs/Twist`.
 5. **Publish**: Result is published on `/control` topic.
 
@@ -58,14 +58,24 @@ Kompass extends the standard ros-sugar types with navigation-specific processing
 `Trackings` and `Detections` require the optional `automatika_embodied_agents` package.
 :::
 
-### kompass-core Data Types
+### Callback Output Types
 
-The callback outputs above use data structures from `kompass_core` -- these are pure Python/C++ types with **no ROS dependency**, keeping `kompass-core` framework-agnostic:
+Sensor payloads are carried by Sugarcoat's containers, which sit closest to the ROS message:
+
+- **`LaserScanData`** (`ros_sugar.io`) -- structured laser scan with angle/range arrays.
+- **`PointCloudData`** (`ros_sugar.io`) -- raw PointCloud2 buffer plus its layout, with cartesian points decoded lazily via `.xyz`.
+
+The navigation types come from `kompass_core` -- pure Python/C++ with **no ROS dependency**, keeping `kompass-core` framework-agnostic:
 
 - **`RobotState`** (`kompass_core.models`) -- position (x, y, yaw), velocity (vx, vy, omega), and speed.
-- **`LaserScanData`** (`kompass_core.datatypes`) -- structured laser scan with angle/range arrays.
-- **`PointCloudData`** (`kompass_core.datatypes`) -- 3D point cloud representation with field offsets.
 - **`Bbox2D`** (`kompass_core.datatypes`) -- 2D bounding box for vision-based tracking.
+
+:::{note}
+`kompass-core` has no sensor container of its own: its algorithms take the
+fields directly (`ranges`/`angles`, or the raw cloud buffer and its layout), so
+a sensor payload is never re-wrapped on its way from the ROS message to the
+C++ kernels.
+:::
 
 ## Creating a Custom Callback
 
@@ -326,7 +336,7 @@ At runtime, the Controller component looks up the corresponding config class fro
 
 `kompass-core` algorithms that operate on spatial data (local mapping, DWA obstacle checking, etc.) can leverage GPU acceleration through [AdaptiveCpp](https://github.com/AdaptiveCpp/AdaptiveCpp) (SYCL). The acceleration is transparent to the data type layer:
 
-- The same `LaserScanData` / `PointCloudData` types are used regardless of CPU or GPU execution.
+- The same `LaserScanData` / `PointCloudData` containers are used regardless of CPU or GPU execution.
 - GPU memory transfers are handled internally by `kompass-core`'s C++ layer.
 - No code changes are needed in the Kompass Python layer to enable GPU acceleration.
 

--- a/kompass/kompass/__init__.py
+++ b/kompass/kompass/__init__.py
@@ -7,7 +7,7 @@ from packaging import version as pkg_version
 
 # Minimum required versions
 MIN_KOMPASS_CORE_VERSION = "0.8.1"
-MIN_SUGARCOAT_VERSION = "0.7.1"
+MIN_SUGARCOAT_VERSION = "0.8.0"
 
 
 def _print_sugarcoat_error(current_version=None):

--- a/kompass/kompass/__init__.py
+++ b/kompass/kompass/__init__.py
@@ -6,7 +6,7 @@ from importlib.metadata import version, PackageNotFoundError
 from packaging import version as pkg_version
 
 # Minimum required versions
-MIN_KOMPASS_CORE_VERSION = "0.8.1"
+MIN_KOMPASS_CORE_VERSION = "0.8.2"
 MIN_SUGARCOAT_VERSION = "0.8.0"
 
 

--- a/kompass/kompass/callbacks.py
+++ b/kompass/kompass/callbacks.py
@@ -7,17 +7,10 @@ from ros_sugar.io import GenericCallback, OccupancyGridCallback
 from ros_sugar.io import OdomCallback as BaseOdomCallback
 from ros_sugar.io import PointCallback as BasePointCallback
 from ros_sugar.io import PoseCallback as BasePoseCallback
-from ros_sugar.io import get_logger
-from kompass_core.datatypes import (
-    LaserScanData,
-    PointCloudData,
-)
-from kompass_core.utils import geometry as GeometryUtils
+from ros_sugar.io import LaserScanCallback, PointCloudCallback
 from kompass_core.models import RobotState
-from kompass_cpp.types import PointFieldType
 
 from nav_msgs.msg import Odometry
-from sensor_msgs.msg import LaserScan
 from tf2_ros import TransformStamped
 from geometry_msgs.msg import Point, Pose
 
@@ -35,6 +28,7 @@ __all__ = [
     "PoseCallback",
     "PoseStampedCallback",
     "LaserScanCallback",
+    "PointCloudCallback",
     "OccupancyGridCallback",
     "TrackingsCallback",
     "DetectionsCallback",
@@ -389,195 +383,6 @@ class CameraInfoCallback(GenericCallback):
             "focal_length": np.array([cam_intrinsics[0], cam_intrinsics[4]]),
             "principal_point": np.array([cam_intrinsics[2], cam_intrinsics[5]]),
         }
-
-
-class LaserScanCallback(GenericCallback):
-    """ROS2 LaserScan Callback Handler to process and transform sensor_msgs/LaserScan data"""
-
-    def __init__(
-        self,
-        input_topic,
-        node_name: Optional[str] = None,
-        transformation: Optional[TransformStamped] = None,
-    ) -> None:
-        """__init__.
-
-        :param input_topic:
-        :param node_name:
-        :type node_name: Optional[str]
-        :param transformation:
-        :type transformation: Optional[TransformStamped]
-        :rtype: None
-        """
-        super().__init__(input_topic, node_name)
-        self.__tf = transformation
-
-    @property
-    def transformation(self) -> Optional[TransformStamped]:
-        """Getter of the laserscan transformation
-
-        :return: Frame transformation
-        :rtype: Optional[TransformStamped]
-        """
-        return self.__tf
-
-    @transformation.setter
-    def transformation(self, transform: TransformStamped):
-        """
-        Sets a new transformation value
-
-        :param transform: Detected transform from source to desired goal frame
-        :type transform: TransformStamped
-        """
-        self.__tf = transform
-
-    def _get_output(
-        self,
-        transformation: Optional[TransformStamped] = None,
-        **_,
-    ) -> Optional[LaserScanData]:
-        """
-        Gets the laserscan data by applying the transformation if given.
-        :returns:   Topic content
-        :rtype:     Optional[LaserScanData]
-        """
-        if not self.msg:
-            return None
-        if transformation or self.transformation:
-            laser_scan_data = self._transform(
-                self.msg, transformation or self.transformation
-            )
-        else:
-            laser_scan_data = self._process(self.msg)
-
-        return laser_scan_data
-
-    def _process(self, msg: LaserScan) -> LaserScanData:
-        """
-        Takes LaserScan ROS message and converts it to LaserScanData
-        :return: LaserScanData
-        """
-        _no_nan_ranges = np.nan_to_num(msg.ranges, nan=msg.range_max)
-        ranges = _no_nan_ranges.clip(min=0.0, max=msg.range_max)
-
-        return LaserScanData(
-            angle_min=msg.angle_min,
-            angle_max=msg.angle_max,
-            angle_increment=msg.angle_increment,
-            time_increment=msg.time_increment,
-            scan_time=msg.scan_time,
-            range_min=msg.range_min,
-            range_max=msg.range_max,
-            ranges=ranges,
-            intensities=np.array(msg.intensities),
-        )
-
-    def _transform(self, msg: LaserScan, transform: TransformStamped) -> LaserScanData:
-        """
-        Applies a transform to a given LaserScan message and converts it to LaserScanData
-
-        :param msg: LaserScan message in source frame
-        :type msg: LaserScan
-        :param transform: LaserScan transform from current to goal frame
-        :type transform: TransformStamped
-
-        :return: LaserScanData in goal frame
-        :rtype: LaserScanData
-        """
-        laserscan_transformed = LaserScanData()
-
-        trans = transform.transform.translation
-        quat = transform.transform.rotation
-
-        _no_nan_ranges = np.nan_to_num(msg.ranges, nan=msg.range_max)
-        ranges = _no_nan_ranges.clip(min=0.0, max=msg.range_max)
-
-        # Get the transformed laser scan data
-        laserscan_transformed = (
-            GeometryUtils.get_laserscan_transformed_polar_coordinates(
-                angle_min=msg.angle_min,
-                angle_max=msg.angle_max,
-                angle_increment=msg.angle_increment,
-                laser_scan_ranges=ranges,
-                max_scan_range=msg.range_max,
-                translation=[trans.x, trans.y, trans.z],
-                rotation=[quat.x, quat.y, quat.z, quat.w],
-            )
-        )
-
-        laserscan_transformed.time_increment = msg.time_increment
-        laserscan_transformed.scan_time = msg.scan_time
-
-        return laserscan_transformed
-
-
-class PointCloudCallback(GenericCallback):
-    """ROS2 PointCloud Callback Handler to process and transform sensor_msgs/PointCloud2 data"""
-
-    def __init__(
-        self,
-        input_topic,
-        node_name: Optional[str] = None,
-    ) -> None:
-        """__init__.
-
-        :param input_topic:
-        :param node_name:
-        :type node_name: Optional[str]
-        :rtype: None
-        """
-        super().__init__(input_topic, node_name)
-        self.__x_field_datatype: Optional[PointFieldType] = None
-
-    @property
-    def field_type(self) -> Optional[PointFieldType]:
-        """Getter of the point cloud fields datatype (from the X field)
-
-        :return: Data type
-        :rtype: Optional[PointFieldType]
-        """
-        return self.__x_field_datatype
-
-    def _get_output(
-        self,
-        **_,
-    ) -> Optional[PointCloudData]:
-        """Gets the PointCloud2 message data in 2D or 3D by applying the transformation if given.
-
-        :return: Return PointCloudData
-        :rtype: Optional[PointCloudData]
-        """
-        if not self.msg:
-            return None
-
-        if self.msg.is_bigendian:
-            raise TypeError("Bigendian data is not supported")
-
-        pc = PointCloudData(
-            point_step=self.msg.point_step,
-            row_step=self.msg.row_step,
-            data=np.array(self.msg.data, dtype=np.int8),
-            height=self.msg.height,
-            width=self.msg.width,
-        )
-
-        for field in self.msg.fields:
-            if field.name == "x":
-                pc.x_offset = field.offset
-                # Get the x field point type
-                self.__x_field_datatype = PointFieldType.from_int(field.datatype)
-            elif field.name == "y":
-                pc.y_offset = field.offset
-            elif field.name == "z":
-                pc.z_offset = field.offset
-
-        if pc.x_offset is None or pc.y_offset is None or pc.z_offset is None:
-            get_logger(self.node_name).warning(
-                "Offsets for x, y, z are not found, point cloud data is null"
-            )
-            return None
-
-        return pc
 
 
 class TwistStampedCallback(GenericCallback):

--- a/kompass/kompass/components/_vision_follower.py
+++ b/kompass/kompass/components/_vision_follower.py
@@ -62,6 +62,18 @@ class VisionFollower:
             return None
         return self._vision_controller.optimal_path()
 
+    @property
+    def _depth_tf_listener(self):
+        """Transform listener from the depth camera frame to the robot body.
+
+        The camera frame is read from the camera info messages, so this is
+        None until the first one arrives.
+        """
+        cmp = self._component
+        return cmp.input_tf_listener(
+            TopicsKeys.DEPTH_CAM_INFO, cmp.config.frames.robot_base, static_tf=True
+        )
+
     def setup(self) -> bool:
         """Build the core vision controller. Stores it on success.
 
@@ -74,7 +86,11 @@ class VisionFollower:
         # Get the depth image transform if the input is provided
         if cmp.in_topic_name(TopicsKeys.DEPTH_CAM_INFO):
             while (
-                not (cmp.depth_tf_listener.got_transform and self.depth_image_info)
+                not (
+                    (depth_tf := self._depth_tf_listener)
+                    and depth_tf.got_transform
+                    and self.depth_image_info
+                )
                 and timeout < cmp.config.topic_subscription_timeout
             ):
                 self._update_inputs()
@@ -117,10 +133,11 @@ class VisionFollower:
                 "operate in GLOBAL frame with velocity tracking"
             )
 
+        depth_tf = self._depth_tf_listener
         config = ControlConfigClasses[cmp.algorithm](
             control_time_step=cmp.config.control_time_step,
-            camera_position_to_robot=cmp.depth_tf_listener.translation,
-            camera_rotation_to_robot=cmp.depth_tf_listener.rotation,
+            camera_position_to_robot=depth_tf.translation if depth_tf else None,
+            camera_rotation_to_robot=depth_tf.rotation if depth_tf else None,
             _use_local_coordinates=use_local,
         )
 

--- a/kompass/kompass/components/_vision_follower.py
+++ b/kompass/kompass/components/_vision_follower.py
@@ -109,16 +109,18 @@ class VisionFollower:
         )
 
         # In vision mode the frame is decided by what's available at setup time:
-        # if odom->world TF (or matching frames) is available we operate in
-        # GLOBAL, otherwise we fall back to LOCAL (robot-relative). Once set,
-        # _frame_mode drives state/sensor handling for the rest of the session.
-        # Reset to GLOBAL before probing so _update_state(block=True) actually
-        # waits for the TF (even if a prior session ended in LOCAL).
+        # if the location->world TF is available we operate in GLOBAL, otherwise
+        # we fall back to LOCAL (robot-relative). Once set, _frame_mode drives
+        # state/sensor handling for the rest of the session. Reset to GLOBAL
+        # before probing so _update_state(block=True) actually waits for the TF
+        # (even if a prior session ended in LOCAL). A robot already localized in
+        # the world frame resolves to the identity transform, so it needs no
+        # special case here.
         cmp.config._frame_mode = FrameMode.GLOBAL
         cmp._update_state(block=True)
         has_tf = (
             cmp.odom_tf_listener is not None and cmp.odom_tf_listener.got_transform
-        ) or (cmp.config.frames.odom == cmp.config.frames.world)
+        )
         cmp.config._frame_mode = FrameMode.GLOBAL if has_tf else FrameMode.LOCAL
         use_local = cmp.config._frame_mode == FrameMode.LOCAL
 

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -11,6 +11,7 @@ from .ros import Topic, update_topics
 from itertools import groupby
 from .defaults import TopicsKeys
 from kompass_core import set_logging_level
+from ..robot import RobotGeometry
 
 
 def _parse_from_topics_dict(
@@ -219,6 +220,20 @@ class Component(BaseComponent):
         :type config: RobotConfig
         """
         self.config.robot = config
+
+    @property
+    def robot_geometry_type(self) -> RobotGeometry.Type:
+        """
+        Getter of the robot geometry as a kompass_core type
+
+        The description carries the geometry as a plain name, since Sugarcoat
+        does no geometry math. The kompass_core helpers compare geometries by
+        enum identity, so convert on the way in.
+
+        :return: Robot geometry type
+        :rtype: RobotGeometry.Type
+        """
+        return RobotGeometry.Type.from_str(self.config.robot.geometry_type)
 
     @property
     def run_type(self) -> ComponentRunType:

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -206,9 +206,22 @@ class Component(BaseComponent):
         """
         Getter of robot config
 
+        Every Kompass component reasons about the robot's body -- its size for
+        collision checking, its velocity envelope for control -- so a missing
+        robot config is an error rather than something to default around.
+
         :return: Robot configuration
         :rtype: RobotConfig
+        :raises ValueError: If no robot configuration has been set
         """
+        if self.config.robot is None:
+            raise ValueError(
+                f"Component '{self.node_name}' requires a robot configuration but "
+                "none is set. Provide one in the recipe, either for the whole stack "
+                "with 'launcher.robot = RobotConfig(...)', for this component with "
+                f"'{self.node_name}.config.robot = RobotConfig(...)', or by attaching "
+                "a robot plugin that supplies it."
+            )
         return self.config.robot
 
     @robot.setter
@@ -233,7 +246,7 @@ class Component(BaseComponent):
         :return: Robot geometry type
         :rtype: RobotGeometry.Type
         """
-        return RobotGeometry.Type.from_str(self.config.robot.geometry_type)
+        return RobotGeometry.Type.from_str(self.robot.geometry_type)
 
     @property
     def run_type(self) -> ComponentRunType:

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -11,7 +11,16 @@ from .ros import Topic, update_topics
 from itertools import groupby
 from .defaults import TopicsKeys
 from kompass_core import set_logging_level
-from ..robot import RobotGeometry
+
+# The runtime counterparts of the robot description: the C++ library defines
+# these, the description in Sugarcoat declares them, and this module is where
+# the two are matched up
+from kompass_core.models import (
+    AngularCtrlLimits as CoreAngularCtrlLimits,
+    LinearCtrlLimits as CoreLinearCtrlLimits,
+    RobotCtrlLimits,
+    RobotGeometry,
+)
 
 
 def _parse_from_topics_dict(
@@ -237,16 +246,47 @@ class Component(BaseComponent):
     @property
     def robot_geometry_type(self) -> RobotGeometry.Type:
         """
-        Getter of the robot geometry as a kompass_core type
+        Getter of the robot geometry as the type the algorithms take
 
         The description carries the geometry as a plain name, since Sugarcoat
-        does no geometry math. The kompass_core helpers compare geometries by
-        enum identity, so convert on the way in.
+        does no geometry math. The algorithms take the type the C++ library
+        defines, so convert on the way in.
 
         :return: Robot geometry type
         :rtype: RobotGeometry.Type
         """
-        return RobotGeometry.Type.from_str(self.robot.geometry_type)
+        return RobotGeometry.from_str(self.robot.geometry_type)
+
+    @property
+    def robot_ctrl_limits(self) -> RobotCtrlLimits:
+        """
+        Getter of the robot velocity envelope as the type the algorithms take
+
+        Counterpart of ``robot_geometry_type`` for the control limits: the
+        description declares them, the C++ library enforces them, and this is
+        the one place the two are matched up.
+
+        :return: Robot control limits
+        :rtype: RobotCtrlLimits
+        """
+        return RobotCtrlLimits(
+            vx_limits=CoreLinearCtrlLimits(
+                max_vel=self.robot.ctrl_vx_limits.max_vel,
+                max_acc=self.robot.ctrl_vx_limits.max_acc,
+                max_decel=self.robot.ctrl_vx_limits.max_decel,
+            ),
+            vy_limits=CoreLinearCtrlLimits(
+                max_vel=self.robot.ctrl_vy_limits.max_vel,
+                max_acc=self.robot.ctrl_vy_limits.max_acc,
+                max_decel=self.robot.ctrl_vy_limits.max_decel,
+            ),
+            omega_limits=CoreAngularCtrlLimits(
+                max_omega=self.robot.ctrl_omega_limits.max_vel,
+                max_ang=self.robot.ctrl_omega_limits.max_steer,
+                max_acc=self.robot.ctrl_omega_limits.max_acc,
+                max_decel=self.robot.ctrl_omega_limits.max_decel,
+            ),
+        )
 
     @property
     def run_type(self) -> ComponentRunType:

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -446,15 +446,19 @@ class Component(BaseComponent):
 
     @property
     def odom_tf_listener(self) -> Optional[TFListener]:
-        """Gets a transform listener for Odometry (from odom to world)
+        """Gets a transform listener from the robot location frame to the world.
 
-        :return:
-        :rtype: TFListener
+        The localization frame is not configured: it is read from the
+        ``header.frame_id`` of the location messages, so this is None until the
+        first one arrives. When the robot is already localized in the world
+        frame the lookup resolves to the identity transform, so "no odometry"
+        needs no special case.
+
+        :return: TF listener from the location frame to the world frame
+        :rtype: Optional[TFListener]
         """
-        if self.config.frames.odom == self.config.frames.world:
-            return None
-        return self.get_transform_listener(
-            self.config.frames.odom, self.config.frames.world
+        return self.input_tf_listener(
+            TopicsKeys.ROBOT_LOCATION, self.config.frames.world
         )
 
     def transform_inputs_to(

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -2,7 +2,7 @@ import time
 import json
 from typing import Dict, List, Optional, Union, Tuple
 from ros_sugar.core import ComponentFallbacks, BaseComponent
-from ros_sugar.tf import TFListener, TFListenerConfig
+from ros_sugar.tf import TFListener
 from ros_sugar.io import Publisher, AllowedTopics
 
 from ..callbacks import GenericCallback
@@ -451,76 +451,61 @@ class Component(BaseComponent):
         :return:
         :rtype: TFListener
         """
-        if not hasattr(self, "_odom_tf_listener"):
-            if self.config.frames.odom != self.config.frames.world:
-                self._odom_tf_listener = self.get_transform_listener(
-                    source_frame=self.config.frames.odom,
-                    goal_frame=self.config.frames.world,
-                )
-            else:
-                self._odom_tf_listener = None
-        return self._odom_tf_listener
+        if self.config.frames.odom == self.config.frames.world:
+            return None
+        return self.get_transform_listener(
+            self.config.frames.odom, self.config.frames.world
+        )
 
-    @property
-    def scan_tf_listener(self) -> TFListener:
-        """Gets a transform listener for LaserScan (from scan to robot base)
+    def transform_inputs_to(
+        self, topic_key: TopicsKeys, goal_frame: str, static_tf: bool = False
+    ) -> None:
+        """Ask for every input under a key to be delivered in a given frame.
 
-        :return:
-        :rtype: TFListener
-        """
-        if not hasattr(self, "_scan_tf_listener"):
-            self._scan_tf_listener = self.get_transform_listener(
-                source_frame=self.config.frames.scan,
-                goal_frame=self.config.frames.robot_base,
-                static_tf=True,
-            )
-        return self._scan_tf_listener
+        Handles keys bound to several topics (such as multiple proximity
+        sensors), each of which carries its own source frame in its messages.
 
-    @property
-    def depth_tf_listener(self) -> TFListener:
-        """Gets a transform listener for LaserScan (from scan to robot base)
-
-        :return:
-        :rtype: TFListener
-        """
-        if not hasattr(self, "_depth_tf_listener"):
-            self._depth_tf_listener = self.get_transform_listener(
-                source_frame=self.config.frames.depth,
-                goal_frame=self.config.frames.robot_base,
-                static_tf=True,
-            )
-        return self._depth_tf_listener
-
-    @property
-    def pc_tf_listener(self) -> TFListener:
-        """Gets a transform listener for LaserScan (from scan to robot base)
-
-        :return:
-        :rtype: TFListener
-        """
-        if not hasattr(self, "_pc_tf_listener"):
-            self._pc_tf_listener = self.get_transform_listener(
-                source_frame=self.config.frames.point_cloud,
-                goal_frame=self.config.frames.robot_base,
-                static_tf=True,
-            )
-        return self._pc_tf_listener
-
-    def get_transform_listener(self, **kwargs) -> TFListener:
-        """Gets a transform listener
-
-        :param src_frame: Source coordinates frame
-        :type src_frame: str
-        :param goal_frame: Goal coordinates frame
+        :param topic_key: Key of the component input topic(s)
+        :type topic_key: TopicsKeys
+        :param goal_frame: Frame the data should be expressed in
         :type goal_frame: str
-
-        :return: TF listener object
-        :rtype: TFListener
+        :param static_tf: Whether the sensors are rigidly mounted
+        :type static_tf: bool
         """
-        # Configure transform source and goal frames
-        tf_config = TFListenerConfig(**kwargs)
-        tf_listener: TFListener = self.create_tf_listener(tf_config)
-        return tf_listener
+        names = self.in_topic_name(topic_key)
+        if not names:
+            return
+        for name in names if isinstance(names, list) else [names]:
+            self.transform_input_to(name, goal_frame, static_tf=static_tf)
+
+    def input_tf_listener(
+        self, topic_key: TopicsKeys, goal_frame: str, static_tf: bool = False
+    ) -> Optional[TFListener]:
+        """Gets a transform listener from an input's own frame to a given frame.
+
+        The source frame is not configured anywhere: it is read from the
+        ``header.frame_id`` of the data itself. This is the counterpart of
+        ``transform_input_to``, for algorithms that need the transform (its
+        translation and rotation) rather than transformed data.
+
+        :param topic_key: Key of the component input topic
+        :type topic_key: TopicsKeys
+        :param goal_frame: Frame to transform into, usually one of ``config.frames``
+        :type goal_frame: str
+        :param static_tf: Whether the sensor is rigidly mounted
+        :type static_tf: bool
+
+        :return: TF listener, or None until the first message on that input
+            arrives. Data already in the goal frame yields a listener that
+            resolves to the identity transform.
+        :rtype: Optional[TFListener]
+        """
+        callback = self.get_callback(topic_key)
+        if not callback or not callback.frame_id:
+            return None
+        return self.get_transform_listener(
+            callback.frame_id, goal_frame, static_tf=static_tf
+        )
 
     def _wait_for_tf(self, tf_listener: TFListener, description: str = "") -> bool:
         """Block up to ``config.topic_subscription_timeout`` waiting for a

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -842,10 +842,9 @@ class Controller(Component):
         if not state_callback:
             return None
         kw = {"get_front": True, "clear_last": True}
-        if self.config.frames.odom != self.config.frames.world:
-            kw["transformation"] = (
-                self.odom_tf_listener.transform if self.odom_tf_listener else None
-            )
+        kw["transformation"] = (
+            self.odom_tf_listener.transform if self.odom_tf_listener else None
+        )
         return state_callback.get_output(**kw)
 
     def _update_state(self, block: bool = True) -> None:
@@ -853,9 +852,10 @@ class Controller(Component):
         Updates node inputs from associated callbacks.
 
         :param block: If True, blocks up to ``topic_subscription_timeout`` waiting
-            for the odom->world TF when the two frames differ. Pass ``False`` from
-            fast control loops to read the latest cached transform without blocking;
-            if the TF is not yet available the update is skipped for this tick.
+            for a robot location message and then for the transform from its own
+            frame to the world frame. Pass ``False`` from fast control loops to
+            read the latest cached transform without blocking; if the TF is not
+            yet available the update is skipped for this tick.
         """
         if self.config._mode == ControllerMode.PATH_FOLLOWER:
             plan_callback = self.get_callback(TopicsKeys.GLOBAL_PLAN)
@@ -865,28 +865,55 @@ class Controller(Component):
 
         # In LOCAL frame mode robot state is irrelevant: sensor data and
         # tracked targets are reasoned about robot-relative.
-        if (
-            block
-            and self.config._frame_mode == FrameMode.GLOBAL
-            and self.config.frames.odom != self.config.frames.world
-        ):
+        if block and self.config._frame_mode == FrameMode.GLOBAL:
             timeout = 0.0
-            odom_listener = self.odom_tf_listener
+            step = 1 / self.config.loop_rate
+            state_callback = self.get_callback(TopicsKeys.ROBOT_LOCATION)
+
+            # The location frame is carried by the messages, so wait for one to
+            # arrive before waiting for its transform. Both waits share a single
+            # timeout budget.
             while (
-                not odom_listener.transform
+                state_callback
+                and not state_callback.got_msg
                 and timeout < self.config.topic_subscription_timeout
             ):
                 self.get_logger().warning(
-                    f"Waiting to get TF from {self.config.frames.odom} frame to {self.config.frames.world} frame...",
+                    "Waiting for a robot location message...", once=True
+                )
+                timeout += step
+                time.sleep(step)
+
+            if state_callback and state_callback.got_msg and not state_callback.frame_id:
+                # A bare Pose carries no header, so there is no frame to look up
+                # and nothing to transform: take the data as it arrived.
+                self.get_logger().warning(
+                    "Robot location messages carry no frame_id -> treating them as "
+                    f"already expressed in the '{self.config.frames.world}' frame",
                     once=True,
                 )
-                timeout += 1 / self.config.loop_rate
-                time.sleep(1 / self.config.loop_rate)
-            if not self.odom_tf_listener.transform:
-                self.get_logger().error(
-                    f"Could not get TF from {self.config.frames.odom} frame to {self.config.frames.world} frame after {self.config.topic_subscription_timeout} seconds"
-                )
-                return
+            else:
+                odom_listener = self.odom_tf_listener
+                while (
+                    odom_listener
+                    and not odom_listener.transform
+                    and timeout < self.config.topic_subscription_timeout
+                ):
+                    self.get_logger().warning(
+                        f"Waiting to get TF from {odom_listener.config.source_frame} "
+                        f"frame to {self.config.frames.world} frame...",
+                        once=True,
+                    )
+                    timeout += step
+                    time.sleep(step)
+
+                if not odom_listener or not odom_listener.transform:
+                    self.get_logger().error(
+                        "Could not get TF from the robot location frame to "
+                        f"'{self.config.frames.world}' frame after "
+                        f"{self.config.topic_subscription_timeout} seconds"
+                    )
+                    return
         self.robot_state = self._read_robot_state()
         if block:
             waited = 0.0

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -35,7 +35,6 @@ from .ros import (
     update_topics,
 )
 from ..utils import component_action
-from ..callbacks import PointCloudCallback
 
 # KOMPASS MSGS/SRVS/ACTIONS
 from .component import Component, TFListener
@@ -1264,7 +1263,6 @@ class Controller(Component):
                 self._lat_dist_error
             )
             feedback_msg.global_path_deviation.orientation_error = self._ori_error
-            feedback_msg.prediction_horizon = self.config.prediction_horizon
 
             self.get_logger().info(
                 "Controlling Path — lat_err=%.3f, ori_err=%.3f"

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -9,7 +9,6 @@ from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 
 # ROS MSGS
 from nav_msgs.msg import Path
-from sensor_msgs.msg import PointCloud2
 from geometry_msgs.msg import PoseStamped
 
 # KOMPASS
@@ -804,19 +803,25 @@ class Controller(Component):
         self.custom_create_all_subscribers()
         self.custom_create_all_action_servers()
 
+    @property
+    def _sensor_tf_listener(self) -> Optional[TFListener]:
+        """Transform listener from the proximity sensor frame to the robot body.
+
+        Resolved from the sensor data's own frame, so it is None until the
+        first message arrives.
+        """
+        return self.input_tf_listener(
+            TopicsKeys.SPATIAL_SENSOR, self.config.frames.robot_base, static_tf=True
+        )
+
     def _update_sensor_data(self) -> None:
         """Update sensor data from the sensor callback"""
         if self.direct_sensor:
             self.local_map = None
             sensor_callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)
+            # The sensor->body transform is applied by the callback itself
             self.sensor_data = (
-                sensor_callback.get_output(
-                    transformation=self._sensor_tf_listener.transform
-                    if self._sensor_tf_listener
-                    else None
-                )
-                if sensor_callback
-                else None
+                sensor_callback.get_output() if sensor_callback else None
             )
         else:
             self.sensor_data = None
@@ -968,14 +973,12 @@ class Controller(Component):
         self._cmds_queue: Queue = Queue()
 
         if self.direct_sensor:
-            sensor_topic = self._inputs_list[
-                self._inputs_keys.index(TopicsKeys.SPATIAL_SENSOR)
-            ]
-            # Setup transform listener
-            self._sensor_tf_listener: TFListener = (
-                self.pc_tf_listener
-                if sensor_topic.msg_type._ros_type == PointCloud2
-                else self.scan_tf_listener
+            # Sensor data is used in the robot body frame. Its own frame comes
+            # from the incoming messages, whatever the sensor type
+            self.transform_inputs_to(
+                TopicsKeys.SPATIAL_SENSOR,
+                self.config.frames.robot_base,
+                static_tf=True,
             )
 
             self.sensor_data: Optional[Union[LaserScanData, PointCloudData]] = None
@@ -984,12 +987,13 @@ class Controller(Component):
 
         if self.config._mode == ControllerMode.PATH_FOLLOWER:
             config_kwargs = {}
-            if self.direct_sensor and self._sensor_tf_listener.got_transform:
+            sensor_tf = self._sensor_tf_listener if self.direct_sensor else None
+            if sensor_tf and sensor_tf.got_transform:
                 config_kwargs["proximity_sensor_position_to_robot"] = (
-                    self._sensor_tf_listener.translation
+                    sensor_tf.translation
                 )
                 config_kwargs["proximity_sensor_rotation_to_robot"] = (
-                    self._sensor_tf_listener.rotation
+                    sensor_tf.rotation
                 )
                 config_kwargs["control_time_step"] = self.config.control_time_step
             # Get default controller configuration and update it from user defined config

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -12,8 +12,8 @@ from nav_msgs.msg import Path
 from geometry_msgs.msg import PoseStamped
 
 # KOMPASS
-from kompass_core.models import Robot, RobotCtrlLimits, RobotState
-from kompass_core.datatypes import LaserScanData, PointCloudData
+from kompass_core.models import Robot, RobotState
+from ros_sugar.io import LaserScanData, PointCloudData
 from kompass_core.utils.geometry import from_euler_to_quaternion
 from kompass_core.control import (
     ControlClasses,
@@ -970,11 +970,7 @@ class Controller(Component):
         )
 
         # SET robot control limits
-        self._robot_ctr_limits = RobotCtrlLimits(
-            vx_limits=self.robot.ctrl_vx_limits,
-            vy_limits=self.robot.ctrl_vy_limits,
-            omega_limits=self.robot.ctrl_omega_limits,
-        )
+        self._robot_ctr_limits = self.robot_ctrl_limits
 
         self._reached_end = False
         self._lat_dist_error: float = 0.0
@@ -1110,15 +1106,19 @@ class Controller(Component):
             )
             return PathControlStatus.WAITING_INPUTS
 
-        laser_scan = None
-        point_cloud = None
+        ranges = None
+        angles = None
+        points = None
         local_map = None
 
         if self.direct_sensor:
             if isinstance(self.sensor_data, LaserScanData):
-                laser_scan = self.sensor_data
-            else:
-                point_cloud = self.sensor_data
+                ranges = self.sensor_data.ranges
+                angles = self.sensor_data.angles
+            elif isinstance(self.sensor_data, PointCloudData):
+                # The controller works on cartesian obstacle points, decoded
+                # from the raw buffer by the container and cached there
+                points = self.sensor_data.xyz
         else:
             local_map = self.local_map
 
@@ -1128,8 +1128,9 @@ class Controller(Component):
 
         cmd_found: bool = self._path_controller.loop_step(
             current_state=self.robot_state,  # type: ignore
-            laser_scan=laser_scan,
-            point_cloud=point_cloud,
+            ranges=ranges,
+            angles=angles,
+            points=points,
             local_map=local_map,
             local_map_resolution=getattr(self, "local_map_resolution", None),
             debug=self.config.debug,

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -974,17 +974,17 @@ class Controller(Component):
 
         # INIT PATH CONTROLLER
         self._robot = Robot(
-            robot_type=self.config.robot.model_type,
+            robot_type=self.robot.model_type,
             geometry_type=self.robot_geometry_type,
-            geometry_params=self.config.robot.geometry_params,
+            geometry_params=self.robot.geometry_params,
             state=self.robot_state or RobotState(),
         )
 
         # SET robot control limits
         self._robot_ctr_limits = RobotCtrlLimits(
-            vx_limits=self.config.robot.ctrl_vx_limits,
-            vy_limits=self.config.robot.ctrl_vy_limits,
-            omega_limits=self.config.robot.ctrl_omega_limits,
+            vx_limits=self.robot.ctrl_vx_limits,
+            vy_limits=self.robot.ctrl_vy_limits,
+            omega_limits=self.robot.ctrl_omega_limits,
         )
 
         self._reached_end = False

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -935,17 +935,6 @@ class Controller(Component):
         if plan_callback:
             plan_callback.on_callback_execute(self._set_path_to_controller)
 
-        if self.direct_sensor:
-            # If direct sensor information is used set maximum range for PointCloud data
-            sensor_callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)
-            if isinstance(sensor_callback, PointCloudCallback):
-                sensor_callback.max_range = (
-                    self.config.prediction_horizon * self.robot.ctrl_vx_limits.max_vel
-                )
-                self.get_logger().info(
-                    f"Setting PointCloud max range to robot max forward horizon '{sensor_callback.max_range}' to limit computations"
-                )
-
     def _set_path_to_controller(self, msg, **_) -> None:
         """
         Set a new plan to the controller/follower
@@ -1337,8 +1326,8 @@ class Controller(Component):
         dist: float = self.robot_state.distance(goal_point)
         return dist <= self._path_controller._config.goal_dist_tolerance
 
-    def _execution_once(self):
-        """Intialize controller post activation"""
+    def _execute_once(self):
+        """Initialize controller post activation"""
         if self.config._mode == ControllerMode.VISION_FOLLOWER:
             # Set up the vision controller eagerly to avoid first-call overhead
             # in the action server.

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -975,7 +975,7 @@ class Controller(Component):
         # INIT PATH CONTROLLER
         self._robot = Robot(
             robot_type=self.config.robot.model_type,
-            geometry_type=self.config.robot.geometry_type,
+            geometry_type=self.robot_geometry_type,
             geometry_params=self.config.robot.geometry_params,
             state=self.robot_state or RobotState(),
         )

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -243,11 +243,11 @@ class DriveManager(Component):
         self._cmds_queue: Queue = Queue()
 
         self.robot_radius = RobotGeometry.get_radius(
-            self.robot_geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.robot.geometry_params
         )
 
         self.robot_height = RobotGeometry.get_height(
-            self.robot_geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.robot.geometry_params
         )
 
         if not self.robot_radius:
@@ -904,20 +904,20 @@ class DriveManager(Component):
         # Use a low pass filter based on maximum allowed acceleration if multi commands are available
         self._filtered_linear_commands_x = self.__filter_multi_cmds(
             output.linear_velocities.x,
-            self.config.robot.ctrl_vx_limits.max_acc,
-            self.config.robot.ctrl_vx_limits.max_vel,
+            self.robot.ctrl_vx_limits.max_acc,
+            self.robot.ctrl_vx_limits.max_vel,
         )
 
         self._filtered_linear_commands_y = self.__filter_multi_cmds(
             output.linear_velocities.y,
-            self.config.robot.ctrl_vy_limits.max_acc,
-            self.config.robot.ctrl_vy_limits.max_vel,
+            self.robot.ctrl_vy_limits.max_acc,
+            self.robot.ctrl_vy_limits.max_vel,
         )
 
         self._filtered_angular_commands = self.__filter_multi_cmds(
             output.angular_velocities.z,
-            self.config.robot.ctrl_omega_limits.max_acc,
-            self.config.robot.ctrl_omega_limits.max_vel,
+            self.robot.ctrl_omega_limits.max_acc,
+            self.robot.ctrl_omega_limits.max_vel,
         )
 
     def _check_bounds(self, target, previous, max_acc, max_decel, freq):
@@ -958,15 +958,15 @@ class DriveManager(Component):
         if self._check_bounds(
             output.linear.x,
             self._previous_command.linear.x,
-            self.config.robot.ctrl_vx_limits.max_acc,
-            self.config.robot.ctrl_vx_limits.max_decel,
+            self.robot.ctrl_vx_limits.max_acc,
+            self.robot.ctrl_vx_limits.max_decel,
             self.config.loop_rate,
         ):
             _cmd.linear.x = self._limit_command_acc(
                 output.linear.x,
                 self._previous_command.linear.x,
-                self.config.robot.ctrl_vx_limits.max_acc,
-                self.config.robot.ctrl_vx_limits.max_decel,
+                self.robot.ctrl_vx_limits.max_acc,
+                self.robot.ctrl_vx_limits.max_decel,
                 self.config.loop_rate,
             )
         else:
@@ -975,15 +975,15 @@ class DriveManager(Component):
         if self._check_bounds(
             output.linear.y,
             self._previous_command.linear.y,
-            self.config.robot.ctrl_vy_limits.max_acc,
-            self.config.robot.ctrl_vy_limits.max_decel,
+            self.robot.ctrl_vy_limits.max_acc,
+            self.robot.ctrl_vy_limits.max_decel,
             self.config.loop_rate,
         ):
             _cmd.linear.y = self._limit_command_acc(
                 output.linear.y,
                 self._previous_command.linear.y,
-                self.config.robot.ctrl_vy_limits.max_acc,
-                self.config.robot.ctrl_vy_limits.max_decel,
+                self.robot.ctrl_vy_limits.max_acc,
+                self.robot.ctrl_vy_limits.max_decel,
                 self.config.loop_rate,
             )
         else:
@@ -993,15 +993,15 @@ class DriveManager(Component):
         if self._check_bounds(
             output.angular.z,
             self._previous_command.angular.z,
-            self.config.robot.ctrl_omega_limits.max_acc,
-            self.config.robot.ctrl_omega_limits.max_decel,
+            self.robot.ctrl_omega_limits.max_acc,
+            self.robot.ctrl_omega_limits.max_decel,
             self.config.loop_rate,
         ):
             _cmd.angular.z = self._limit_command_acc(
                 output.angular.z,
                 self._previous_command.angular.z,
-                self.config.robot.ctrl_omega_limits.max_acc,
-                self.config.robot.ctrl_omega_limits.max_decel,
+                self.robot.ctrl_omega_limits.max_acc,
+                self.robot.ctrl_omega_limits.max_decel,
                 self.config.loop_rate,
             )
         else:
@@ -1068,28 +1068,28 @@ class DriveManager(Component):
         :rtype: bool
         """
 
-        if abs(output[0]) > self.config.robot.ctrl_vx_limits.max_vel:
+        if abs(output[0]) > self.robot.ctrl_vx_limits.max_vel:
             self.get_logger().debug(
-                f"Limiting linear velocity by allowed maximum {self.config.robot.ctrl_vx_limits.max_vel}"
+                f"Limiting linear velocity by allowed maximum {self.robot.ctrl_vx_limits.max_vel}"
             )
-            output[0] = np.sign(output[0]) * self.config.robot.ctrl_vx_limits.max_vel
-        elif abs(output[0]) < self.config.robot.ctrl_vx_limits.min_absolute_val:
+            output[0] = np.sign(output[0]) * self.robot.ctrl_vx_limits.max_vel
+        elif abs(output[0]) < self.robot.ctrl_vx_limits.min_absolute_val:
             output[0] = 0.0
 
-        if abs(output[1]) > self.config.robot.ctrl_vy_limits.max_vel:
+        if abs(output[1]) > self.robot.ctrl_vy_limits.max_vel:
             self.get_logger().debug(
-                f"Limiting linear Vy velocity by allowed maximum {self.config.robot.ctrl_vy_limits.max_vel}"
+                f"Limiting linear Vy velocity by allowed maximum {self.robot.ctrl_vy_limits.max_vel}"
             )
-            output[1] = np.sign(output[1]) * self.config.robot.ctrl_vy_limits.max_vel
-        elif abs(output[1]) < self.config.robot.ctrl_vy_limits.min_absolute_val:
+            output[1] = np.sign(output[1]) * self.robot.ctrl_vy_limits.max_vel
+        elif abs(output[1]) < self.robot.ctrl_vy_limits.min_absolute_val:
             output[1] = 0.0
 
-        if abs(output[2]) > self.config.robot.ctrl_omega_limits.max_vel:
+        if abs(output[2]) > self.robot.ctrl_omega_limits.max_vel:
             self.get_logger().debug(
-                f"Limiting angular velocity by allowed maximum {self.config.robot.ctrl_omega_limits.max_vel}"
+                f"Limiting angular velocity by allowed maximum {self.robot.ctrl_omega_limits.max_vel}"
             )
-            output[2] = np.sign(output[2]) * self.config.robot.ctrl_omega_limits.max_vel
-        elif abs(output[2]) < self.config.robot.ctrl_omega_limits.min_absolute_val:
+            output[2] = np.sign(output[2]) * self.robot.ctrl_omega_limits.max_vel
+        elif abs(output[2]) < self.robot.ctrl_omega_limits.min_absolute_val:
             output[2] = 0.0
         return output
 
@@ -1162,7 +1162,7 @@ class DriveManager(Component):
         self.get_logger().info("Got Proximity Sensor TF...")
 
         robot_shape = RobotGeometry.Type.to_kompass_cpp_lib(self.robot_geometry_type)
-        robot_dimensions = self.config.robot.geometry_params
+        robot_dimensions = self.robot.geometry_params
 
         # Get laserscan data to initialize the GPU based checker
         while not self.sensor_data:

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -6,7 +6,8 @@ from attrs import define, field
 from functools import partial
 from geometry_msgs.msg import Twist
 from kompass_core.datatypes import LaserScanData, PointCloudData
-from kompass_core.models import RobotGeometry, RobotState, RobotType
+from kompass_core.models import RobotGeometry, RobotState
+from ..robot import RobotType
 from kompass_interfaces.msg import TwistArray
 from kompass_cpp.types import SensorInputType, PointFieldType
 
@@ -242,11 +243,11 @@ class DriveManager(Component):
         self._cmds_queue: Queue = Queue()
 
         self.robot_radius = RobotGeometry.get_radius(
-            self.config.robot.geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.config.robot.geometry_params
         )
 
         self.robot_height = RobotGeometry.get_height(
-            self.config.robot.geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.config.robot.geometry_params
         )
 
         if not self.robot_radius:
@@ -1160,9 +1161,7 @@ class DriveManager(Component):
 
         self.get_logger().info("Got Proximity Sensor TF...")
 
-        robot_shape = RobotGeometry.Type.to_kompass_cpp_lib(
-            self.config.robot.geometry_type
-        )
+        robot_shape = RobotGeometry.Type.to_kompass_cpp_lib(self.robot_geometry_type)
         robot_dimensions = self.config.robot.geometry_params
 
         # Get laserscan data to initialize the GPU based checker

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -478,9 +478,11 @@ class DriveManager(Component):
             self.get_publisher(TopicsKeys.FINAL_COMMAND).publish([0.0, 0.0, 0.0])
             return
         # Publish command with slowdown
-        self.get_publisher(TopicsKeys.FINAL_COMMAND).publish(
-            [vx_out * slowdown_val, vy_out * slowdown_val, omega_out * slowdown_val]
-        )
+        self.get_publisher(TopicsKeys.FINAL_COMMAND).publish([
+            vx_out * slowdown_val,
+            vy_out * slowdown_val,
+            omega_out * slowdown_val,
+        ])
 
     def execute_cmd_closed_loop(self, output: Twist, max_time: float):
         """Execute a control command in closed loop
@@ -528,25 +530,27 @@ class DriveManager(Component):
             self._publish_cmd(vx_out, vy_out, omega_out)
             time.sleep(_step)
 
-    @component_action(description={
-        "type": "function",
-        "function": {
-            "name": "move_forward",
-            "description": "Move the robot forward by a given distance while checking for obstacles. "
-            "The robot will stop early if an obstacle is detected in the forward direction. "
-            "Use when the user asks the robot to move forward, advance, or go straight ahead.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "max_distance": {
-                        "type": "number",
-                        "description": "Distance to move forward in meters. Map user instructions like 'move forward 1 meter' to max_distance=1.0.",
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "move_forward",
+                "description": "Move the robot forward by a given distance while checking for obstacles. "
+                "The robot will stop early if an obstacle is detected in the forward direction. "
+                "Use when the user asks the robot to move forward, advance, or go straight ahead.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "max_distance": {
+                            "type": "number",
+                            "description": "Distance to move forward in meters. Map user instructions like 'move forward 1 meter' to max_distance=1.0.",
+                        },
                     },
+                    "required": ["max_distance"],
                 },
-                "required": ["max_distance"],
             },
-        },
-    })
+        }
+    )
     def move_forward(self, max_distance: float, **_) -> bool:
         """Moves the robot forward if the forward direction is clear of obstacles
 
@@ -600,25 +604,27 @@ class DriveManager(Component):
         # Return true if unblocking forward is done
         return traveled_distance >= max_distance
 
-    @component_action(description={
-        "type": "function",
-        "function": {
-            "name": "move_backward",
-            "description": "Move the robot backward by a given distance while checking for obstacles behind it. "
-            "The robot will stop early if an obstacle is detected in the backward direction. "
-            "Use when the user asks the robot to move back, reverse, or go backwards.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "max_distance": {
-                        "type": "number",
-                        "description": "Distance to move backward in meters. Map user instructions like 'go back 0.5 meters' to max_distance=0.5.",
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "move_backward",
+                "description": "Move the robot backward by a given distance while checking for obstacles behind it. "
+                "The robot will stop early if an obstacle is detected in the backward direction. "
+                "Use when the user asks the robot to move back, reverse, or go backwards.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "max_distance": {
+                            "type": "number",
+                            "description": "Distance to move backward in meters. Map user instructions like 'go back 0.5 meters' to max_distance=0.5.",
+                        },
                     },
+                    "required": ["max_distance"],
                 },
-                "required": ["max_distance"],
             },
-        },
-    })
+        }
+    )
     def move_backward(self, max_distance: float, **_) -> bool:
         """Moves the robot backwards if the backward direction is clear of obstacles
 
@@ -671,31 +677,33 @@ class DriveManager(Component):
         # Return true if unblocking forward is done
         return traveled_distance >= max_distance
 
-    @component_action(description={
-        "type": "function",
-        "function": {
-            "name": "rotate_in_place",
-            "description": "Rotate the robot in place by a given angle. Checks that the area around the robot is clear before rotating. "
-            "Will not work for Ackermann-type robots (car-like steering). "
-            "Use when the user asks the robot to turn, rotate, spin, or face a different direction.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "max_rotation": {
-                        "type": "number",
-                        "description": "Maximum rotation angle in radians. Convert user requests from degrees to radians "
-                        "(e.g. 'turn 90 degrees' -> max_rotation=1.5708). Positive values rotate counter-clockwise.",
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "rotate_in_place",
+                "description": "Rotate the robot in place by a given angle. Checks that the area around the robot is clear before rotating. "
+                "Will not work for Ackermann-type robots (car-like steering). "
+                "Use when the user asks the robot to turn, rotate, spin, or face a different direction.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "max_rotation": {
+                            "type": "number",
+                            "description": "Maximum rotation angle in radians. Convert user requests from degrees to radians "
+                            "(e.g. 'turn 90 degrees' -> max_rotation=1.5708). Positive values rotate counter-clockwise.",
+                        },
+                        "safety_margin": {
+                            "type": "number",
+                            "description": "Minimum clearance around the robot in meters required to perform the rotation. "
+                            "Defaults to 5% of the robot radius if not specified.",
+                        },
                     },
-                    "safety_margin": {
-                        "type": "number",
-                        "description": "Minimum clearance around the robot in meters required to perform the rotation. "
-                        "Defaults to 5% of the robot radius if not specified.",
-                    },
+                    "required": ["max_rotation"],
                 },
-                "required": ["max_rotation"],
             },
-        },
-    })
+        }
+    )
     def rotate_in_place(
         self, max_rotation: float, safety_margin: Optional[float] = None, **_
     ) -> bool:
@@ -763,9 +771,11 @@ class DriveManager(Component):
             if slowdown_factor == 0.0:
                 unblocking = False
             else:
-                self.get_publisher(TopicsKeys.FINAL_COMMAND).publish(
-                    [0.0, 0.0, self.robot.ctrl_omega_limits.max_vel / 2]
-                )
+                self.get_publisher(TopicsKeys.FINAL_COMMAND).publish([
+                    0.0,
+                    0.0,
+                    self.robot.ctrl_omega_limits.max_vel / 2,
+                ])
                 traveled_radius += self.robot.ctrl_omega_limits.max_vel / (
                     2 * self.config.loop_rate
                 )
@@ -774,45 +784,47 @@ class DriveManager(Component):
         # Return true if unblocking forward is done
         return traveled_radius >= max_rotation
 
-    @component_action(description={
-        "type": "function",
-        "function": {
-            "name": "move_to_unblock",
-            "description": "Attempt to free the robot when it is stuck or blocked by obstacles. "
-            "Tries moving forward first, then backward, then rotating in place until one succeeds. "
-            "Requires sensor data (LaserScan or PointCloud) to check surroundings. "
-            "Use when the robot is stuck, blocked, or unable to proceed along its path.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "max_distance_forward": {
-                        "type": "number",
-                        "description": "Maximum forward distance to try in meters. Defaults to 2x the robot radius.",
+    @component_action(
+        description={
+            "type": "function",
+            "function": {
+                "name": "move_to_unblock",
+                "description": "Attempt to free the robot when it is stuck or blocked by obstacles. "
+                "Tries moving forward first, then backward, then rotating in place until one succeeds. "
+                "Requires sensor data (LaserScan or PointCloud) to check surroundings. "
+                "Use when the robot is stuck, blocked, or unable to proceed along its path.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "max_distance_forward": {
+                            "type": "number",
+                            "description": "Maximum forward distance to try in meters. Defaults to 2x the robot radius.",
+                        },
+                        "max_distance_backwards": {
+                            "type": "number",
+                            "description": "Maximum backward distance to try in meters. Defaults to 2x the robot radius.",
+                        },
+                        "max_rotation": {
+                            "type": "number",
+                            "description": "Maximum rotation angle to try in radians. Defaults to pi/2 (~90 degrees).",
+                        },
+                        "rotation_safety_margin": {
+                            "type": "number",
+                            "description": "Clearance required around the robot to attempt rotation in meters. Defaults to 5% of robot radius.",
+                        },
                     },
-                    "max_distance_backwards": {
-                        "type": "number",
-                        "description": "Maximum backward distance to try in meters. Defaults to 2x the robot radius.",
-                    },
-                    "max_rotation": {
-                        "type": "number",
-                        "description": "Maximum rotation angle to try in radians. Defaults to pi/2 (~90 degrees).",
-                    },
-                    "rotation_safety_margin": {
-                        "type": "number",
-                        "description": "Clearance required around the robot to attempt rotation in meters. Defaults to 5% of robot radius.",
-                    },
+                    "required": [],
                 },
-                "required": [],
             },
-        },
-    })
+        }
+    )
     def move_to_unblock(
         self,
         max_distance_forward: Optional[float] = None,
         max_distance_backwards: Optional[float] = None,
         max_rotation: float = np.pi / 2,
         rotation_safety_margin: Optional[float] = None,
-        **_
+        **_,
     ) -> bool:
         """Moves the robot forward/backward or rotate in place to get out of blocking spots
 
@@ -1110,7 +1122,9 @@ class DriveManager(Component):
             self.get_publisher(TopicsKeys.EMERGENCY).publish(False)
 
         if speed_factor == 0.0:
-            self.get_logger().warning("Emergency stop is ON, no commands will be executed")
+            self.get_logger().warning(
+                "Emergency stop is ON, no commands will be executed"
+            )
             return
 
         # Publish commands in the queue
@@ -1198,6 +1212,10 @@ class DriveManager(Component):
                 f"'{type(self.sensor_data).__name__}' -> Safety Stop is disabled!"
             )
             self._emergency_checker = None
+            # Set failure based on the fact that the spatial sensor is not providing valid data
+            self.health_status.set_fail_system(
+                topic_names=[self.in_topic_name(TopicsKeys.SPATIAL_SENSOR)]
+            )
             return
 
         if self.config.use_gpu:

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -51,7 +51,7 @@ class DriveManagerConfig(ComponentConfig):
       - Filter (smooth) incoming velocity commands to limit the acceleration
 
     * - **cmd_tolerance**
-      - `float`, `0.1`
+      - `float`, `0.05`
       - Tolerance value when checking for reaching the command in closed loop
 
     * - **critical_zone_angle**
@@ -94,7 +94,7 @@ class DriveManagerConfig(ComponentConfig):
     smooth_commands: bool = field(default=False)
 
     cmd_tolerance: float = field(
-        default=0.01
+        default=0.05
     )  # tolerance value when checking for reaching the desired command in closed loop
 
     critical_zone_angle: float = field(

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -5,7 +5,7 @@ from queue import Queue, Empty
 from attrs import define, field
 from functools import partial
 from geometry_msgs.msg import Twist
-from kompass_core.datatypes import LaserScanData, PointCloudData
+from ros_sugar.io import LaserScanData, PointCloudData
 from kompass_core.models import RobotGeometry, RobotState
 from ..robot import RobotType
 from kompass_interfaces.msg import TwistArray
@@ -1161,7 +1161,7 @@ class DriveManager(Component):
 
         self.get_logger().info("Got Proximity Sensor TF...")
 
-        robot_shape = RobotGeometry.Type.to_kompass_cpp_lib(self.robot_geometry_type)
+        robot_shape = self.robot_geometry_type
         robot_dimensions = self.robot.geometry_params
 
         # Get laserscan data to initialize the GPU based checker
@@ -1189,7 +1189,16 @@ class DriveManager(Component):
             }
             if self.config.use_gpu:
                 # this parameter is only used in the GPU kernel
-                kwargs["cloud_field_type"] = PointFieldType.from_int(self.sensor_data.x_field_datatype)
+                kwargs["cloud_field_type"] = PointFieldType.from_int(
+                    self.sensor_data.x_field_datatype
+                )
+        else:
+            self.get_logger().error(
+                f"Cannot initialize CriticalZoneChecker for sensor data of type "
+                f"'{type(self.sensor_data).__name__}' -> Safety Stop is disabled!"
+            )
+            self._emergency_checker = None
+            return
 
         if self.config.use_gpu:
             try:

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -1213,8 +1213,13 @@ class DriveManager(Component):
             )
             self._emergency_checker = None
             # Set failure based on the fact that the spatial sensor is not providing valid data
+            # The key can be bound to several sensors, so the name(s) come back
+            # as a list in that case
+            sensor_names = self.in_topic_name(TopicsKeys.SPATIAL_SENSOR) or []
             self.health_status.set_fail_system(
-                topic_names=[self.in_topic_name(TopicsKeys.SPATIAL_SENSOR)]
+                topic_names=sensor_names
+                if isinstance(sensor_names, list)
+                else [sensor_names]
             )
             return
 

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -8,7 +8,7 @@ from geometry_msgs.msg import Twist
 from kompass_core.datatypes import LaserScanData, PointCloudData
 from kompass_core.models import RobotGeometry, RobotState, RobotType
 from kompass_interfaces.msg import TwistArray
-from kompass_cpp.types import SensorInputType
+from kompass_cpp.types import SensorInputType, PointFieldType
 
 # KOMPASS ROS
 from ..config import BaseValidators, ComponentConfig, ComponentRunType
@@ -269,6 +269,13 @@ class DriveManager(Component):
         # Emergency checker gets initialized on activation to get the sensor transformation
         self._emergency_checker = None
 
+        # Every proximity sensor is handled in the robot body frame. Each one
+        # carries its own frame in its messages, so several sensors mounted in
+        # different places work without configuring any of them
+        self.transform_inputs_to(
+            TopicsKeys.SPATIAL_SENSOR, self.config.frames.robot_base, static_tf=True
+        )
+
         self._attach_callbacks_and_processors()
 
     def _attach_callbacks_and_processors(self):
@@ -393,19 +400,13 @@ class DriveManager(Component):
         for idx in range(num_sensors):
             callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR, idx)
             if isinstance(callback, LaserScanCallback):
-                self.sensor_data: Optional[LaserScanData] = callback.get_output(
-                    transformation=self.scan_tf_listener.transform
-                    if self.scan_tf_listener
-                    else None,
-                )
+                # The sensor->body transform is applied by the callback itself
+                self.sensor_data: Optional[LaserScanData] = callback.get_output()
                 break
             elif isinstance(callback, PointCloudCallback):
                 self.__pc_callback = callback
                 self.sensor_data: Optional[PointCloudData] = (
                     self.__pc_callback.get_output(
-                        transformation=self.scan_tf_listener.transform
-                        if self.scan_tf_listener
-                        else None,
                         get_2d=True,
                         min_z=0.0,
                         max_z=self.robot_height,
@@ -1145,8 +1146,15 @@ class DriveManager(Component):
             self._emergency_checker = None
             return
 
-        # Get transformation from sensor to robot body
-        while not self.scan_tf_listener or not self.scan_tf_listener.transform:
+        # Get transformation from sensor to robot body. The sensor frame comes
+        # from the data itself, so this also waits for the first sensor message
+        sensor_tf = None
+        while not sensor_tf or not sensor_tf.transform:
+            sensor_tf = self.input_tf_listener(
+                TopicsKeys.SPATIAL_SENSOR,
+                self.config.frames.robot_base,
+                static_tf=True,
+            )
             self.get_logger().info("Waiting to get Proximity Sensor TF...", once=True)
             time.sleep(1 / self.config.loop_rate)
 
@@ -1182,7 +1190,7 @@ class DriveManager(Component):
             }
             if self.config.use_gpu:
                 # this parameter is only used in the GPU kernel
-                kwargs["cloud_field_type"] = self.__pc_callback.field_type
+                kwargs["cloud_field_type"] = PointFieldType.from_int(self.sensor_data.x_field_datatype)
 
         if self.config.use_gpu:
             try:
@@ -1191,8 +1199,8 @@ class DriveManager(Component):
                 self._emergency_checker = CriticalZoneCheckerGPU(
                     robot_shape=robot_shape,
                     robot_dimensions=robot_dimensions,
-                    sensor_position_body=self.scan_tf_listener.translation,
-                    sensor_rotation_body=self.scan_tf_listener.rotation,
+                    sensor_position_body=sensor_tf.translation,
+                    sensor_rotation_body=sensor_tf.rotation,
                     critical_angle=self.config.critical_zone_angle,
                     critical_distance=self.config.critical_zone_distance,
                     slowdown_distance=self.config.slowdown_zone_distance,
@@ -1235,8 +1243,8 @@ class DriveManager(Component):
         self._emergency_checker = CriticalZoneChecker(
             robot_shape=robot_shape,
             robot_dimensions=robot_dimensions,
-            sensor_position_body=self.scan_tf_listener.translation,
-            sensor_rotation_body=self.scan_tf_listener.rotation,
+            sensor_position_body=sensor_tf.translation,
+            sensor_rotation_body=sensor_tf.rotation,
             critical_angle=self.config.critical_zone_angle,
             critical_distance=self.config.critical_zone_distance,
             slowdown_distance=self.config.slowdown_zone_distance,

--- a/kompass/kompass/components/map_server.py
+++ b/kompass/kompass/components/map_server.py
@@ -197,7 +197,7 @@ class MapServer(Component):
         self._grid_res: Optional[float] = None
         self._grid_origin: Optional[Pose] = None
         self.robot_height = RobotGeometry.get_height(
-            self.config.robot.geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.config.robot.geometry_params
         )
 
     def create_all_timers(self):

--- a/kompass/kompass/components/map_server.py
+++ b/kompass/kompass/components/map_server.py
@@ -12,7 +12,7 @@ from nav_msgs.msg import OccupancyGrid
 from geometry_msgs.msg import Pose
 import sensor_msgs_py.point_cloud2 as pc2
 from kompass_core.models import RobotGeometry
-from kompass_core.datatypes import get_occupancy_grid_from_pcd, get_points_from_pcd
+from kompass_core.utils import get_occupancy_grid_from_pcd, get_points_from_pcd
 
 # KOMPASS ROS
 from rclpy.callback_groups import ReentrantCallbackGroup

--- a/kompass/kompass/components/map_server.py
+++ b/kompass/kompass/components/map_server.py
@@ -197,7 +197,7 @@ class MapServer(Component):
         self._grid_res: Optional[float] = None
         self._grid_origin: Optional[Pose] = None
         self.robot_height = RobotGeometry.get_height(
-            self.robot_geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.robot.geometry_params
         )
 
     def create_all_timers(self):

--- a/kompass/kompass/components/mapper.py
+++ b/kompass/kompass/components/mapper.py
@@ -187,20 +187,23 @@ class LocalMapper(Component):
         Updates node inputs from associated callbacks
         """
 
-        self.robot_state: Optional[RobotState] = self.get_callback(
-            TopicsKeys.ROBOT_LOCATION
-        ).get_output(
+        location_callback = self.get_callback(TopicsKeys.ROBOT_LOCATION)
+        self.robot_state: Optional[RobotState] = location_callback.get_output(
             transformation=self.odom_tf_listener.transform
             if self.odom_tf_listener
             else None
         )
 
         if self.odom_tf_listener and self.odom_tf_listener.got_transform:
-            # If the transform from odom to world is available, we can set the local map frame to world frame, as the local map will be built in the world frame
+            # The transform to the world frame is available, so robot_state has
+            # been transformed and the local map is built in the world frame
             self._local_map_frame = self.config.frames.world
         else:
-            # If the transform from odom to world is not available, we set the local map frame to odom frame, as the robot_state will be in the odom frame
-            self._local_map_frame = self.config.frames.odom
+            # No transform yet, so robot_state is still in whatever frame the
+            # location messages arrived in, and so is the local map
+            self._local_map_frame = (
+                location_callback.frame_id or self.config.frames.world
+            )
 
         # The sensor->body transform is applied by the callback itself
         callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)

--- a/kompass/kompass/components/mapper.py
+++ b/kompass/kompass/components/mapper.py
@@ -11,7 +11,7 @@ from kompass_core.mapping import LocalMapper as LocalMapperHandler
 from kompass_core.datatypes.scan_model import ScanModelConfig
 from kompass_core.datatypes.pose import PoseData
 from kompass_core.models import RobotState
-from kompass_core.datatypes import LaserScanData, PointCloudData
+from ros_sugar.io import LaserScanData, PointCloudData
 from kompass_core.models import RobotGeometry
 
 # KOMPASS ROS
@@ -252,7 +252,16 @@ class LocalMapper(Component):
         pose_robot_in_world.qz = np.sin(self.robot_state.yaw / 2)
         pose_robot_in_world.qw = np.cos(self.robot_state.yaw / 2)
 
-        self._local_map_builder.update_from_scan(pose_robot_in_world, self.sensor_data)
+        if isinstance(self.sensor_data, LaserScanData):
+            self._local_map_builder.update_from_laserscan(
+                pose_robot_in_world,
+                ranges=self.sensor_data.ranges,
+                angles=self.sensor_data.angles,
+            )
+        else:
+            self._local_map_builder.update_from_pointcloud(
+                pose_robot_in_world, **self.sensor_data.asdict()
+            )
 
     def _execution_step(self):
         """

--- a/kompass/kompass/components/mapper.py
+++ b/kompass/kompass/components/mapper.py
@@ -163,7 +163,7 @@ class LocalMapper(Component):
         )  # Default local map frame is world frame, will be updated to odom frame if the transform from odom to world is not available
 
         self.robot_height = RobotGeometry.get_height(
-            self.robot_geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.robot.geometry_params
         )
 
         self.sensor_data: Optional[Union[LaserScanData, PointCloudData]] = None

--- a/kompass/kompass/components/mapper.py
+++ b/kompass/kompass/components/mapper.py
@@ -18,7 +18,7 @@ from kompass_core.models import RobotGeometry
 from ..config import ComponentConfig
 from .ros import Topic, update_topics
 from .component import Component
-from ..callbacks import LaserScanCallback, PointCloudCallback
+
 from .defaults import (
     TopicsKeys,
     mapper_allowed_inputs,

--- a/kompass/kompass/components/mapper.py
+++ b/kompass/kompass/components/mapper.py
@@ -172,6 +172,12 @@ class LocalMapper(Component):
             config=self.config.map_params, scan_model_config=self.config.scan_model
         )
 
+        # Sensor data is mapped in the robot body frame. The sensor's own frame
+        # comes from the incoming messages, so nothing has to be configured
+        self.transform_inputs_to(
+            TopicsKeys.SPATIAL_SENSOR, self.config.frames.robot_base, static_tf=True
+        )
+
         self.get_callback(TopicsKeys.SPATIAL_SENSOR).on_callback_execute(
             self._update_map_from_scan
         )
@@ -196,15 +202,9 @@ class LocalMapper(Component):
             # If the transform from odom to world is not available, we set the local map frame to odom frame, as the robot_state will be in the odom frame
             self._local_map_frame = self.config.frames.odom
 
+        # The sensor->body transform is applied by the callback itself
         callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)
-        if isinstance(callback, LaserScanCallback):
-            self.sensor_data = callback.get_output(
-                transformation=self.scan_tf_listener.transform
-                if self.scan_tf_listener
-                else None
-            )
-        elif isinstance(callback, PointCloudCallback):
-            self.sensor_data = callback.get_output()
+        self.sensor_data = callback.get_output()
 
     def publish_data(self):
         """

--- a/kompass/kompass/components/mapper.py
+++ b/kompass/kompass/components/mapper.py
@@ -163,7 +163,7 @@ class LocalMapper(Component):
         )  # Default local map frame is world frame, will be updated to odom frame if the transform from odom to world is not available
 
         self.robot_height = RobotGeometry.get_height(
-            self.config.robot.geometry_type, self.config.robot.geometry_params
+            self.robot_geometry_type, self.config.robot.geometry_params
         )
 
         self.sensor_data: Optional[Union[LaserScanData, PointCloudData]] = None

--- a/kompass/kompass/components/motion_server.py
+++ b/kompass/kompass/components/motion_server.py
@@ -422,28 +422,28 @@ class MotionServer(Component):
                     "name": "linear_step_mid",
                     "test": np.full(
                         (number_of_steps, 2),
-                        [self.config.robot.ctrl_vx_limits.max_vel / 2, 0.0],
+                        [self.robot.ctrl_vx_limits.max_vel / 2, 0.0],
                     ),
                 },
                 {
                     "name": "linear_step_inv",
                     "test": np.full(
                         (number_of_steps, 2),
-                        [-self.config.robot.ctrl_vx_limits.max_vel / 2, 0.0],
+                        [-self.robot.ctrl_vx_limits.max_vel / 2, 0.0],
                     ),
                 },
                 {
                     "name": "ang_step_mid",
                     "test": np.full(
                         (number_of_steps, 2),
-                        [0.0, self.config.robot.ctrl_omega_limits.max_vel / 2],
+                        [0.0, self.robot.ctrl_omega_limits.max_vel / 2],
                     ),
                 },
                 {
                     "name": "ang_step_inv",
                     "test": np.full(
                         (number_of_steps, 2),
-                        [0.0, -self.config.robot.ctrl_omega_limits.max_vel / 2],
+                        [0.0, -self.robot.ctrl_omega_limits.max_vel / 2],
                     ),
                 },
             ]
@@ -454,8 +454,8 @@ class MotionServer(Component):
                     "test": np.full(
                         (number_of_steps, 2),
                         [
-                            self.config.robot.ctrl_vx_limits.max_vel / 2,
-                            self.config.robot.ctrl_omega_limits.max_vel / 2,
+                            self.robot.ctrl_vx_limits.max_vel / 2,
+                            self.robot.ctrl_omega_limits.max_vel / 2,
                         ],
                     ),
                 },
@@ -464,8 +464,8 @@ class MotionServer(Component):
                     "test": np.full(
                         (number_of_steps, 2),
                         [
-                            -self.config.robot.ctrl_vx_limits.max_vel / 2,
-                            self.config.robot.ctrl_omega_limits.max_vel / 2,
+                            -self.robot.ctrl_vx_limits.max_vel / 2,
+                            self.robot.ctrl_omega_limits.max_vel / 2,
                         ],
                     ),
                 },
@@ -474,8 +474,8 @@ class MotionServer(Component):
                     "test": np.full(
                         (number_of_steps, 2),
                         [
-                            self.config.robot.ctrl_vx_limits.max_vel / 2,
-                            -self.config.robot.ctrl_omega_limits.max_vel / 2,
+                            self.robot.ctrl_vx_limits.max_vel / 2,
+                            -self.robot.ctrl_omega_limits.max_vel / 2,
                         ],
                     ),
                 },
@@ -484,8 +484,8 @@ class MotionServer(Component):
                     "test": np.full(
                         (number_of_steps, 2),
                         [
-                            -self.config.robot.ctrl_vx_limits.max_vel / 2,
-                            -self.config.robot.ctrl_omega_limits.max_vel / 2,
+                            -self.robot.ctrl_vx_limits.max_vel / 2,
+                            -self.robot.ctrl_omega_limits.max_vel / 2,
                         ],
                     ),
                 },

--- a/kompass/kompass/components/planner.py
+++ b/kompass/kompass/components/planner.py
@@ -417,9 +417,7 @@ class Planner(Component):
                         msg, callback=_cb, goal_index=_idx
                     )
                 )
-        if require_cam_info and not self.got_all_inputs(
-            inputs_to_check=[self.in_topic_name(TopicsKeys.DEPTH_CAM_INFO)]
-        ):
+        if require_cam_info and not self.in_topic_name(TopicsKeys.DEPTH_CAM_INFO):
             raise ValueError(
                 f"At least one of the goal point callbacks is a {callback.__class__.__name__} which requires depth camera info input. Please provide a topic for {TopicsKeys.DEPTH_CAM_INFO} to ensure proper functionality."
             )

--- a/kompass/kompass/components/planner.py
+++ b/kompass/kompass/components/planner.py
@@ -25,7 +25,7 @@ from ..config import BaseValidators, ComponentConfig, ComponentRunType
 from ..data_types import Path as KompassPath
 from ..callbacks import PointsOfInterestCallback, DetectionsCallback
 from .ros import Topic, update_topics, ActionClientHandler
-from .component import Component
+from .component import Component, TFListener
 from .defaults import (
     TopicsKeys,
     planner_allowed_inputs,
@@ -711,13 +711,26 @@ class Planner(Component):
                 to_robot_state=True, robot_state=self.robot_state
             )
 
+    @property
+    def _depth_tf_listener(self) -> Optional[TFListener]:
+        """Transform listener from the depth camera frame to the robot body.
+
+        The camera frame is read from the camera info messages, so this is
+        None until the first one arrives.
+        """
+        return self.input_tf_listener(
+            TopicsKeys.DEPTH_CAM_INFO, self.config.frames.robot_base, static_tf=True
+        )
+
     def __setup_depth_detector(self) -> Optional[DepthDetector]:
         """Setup and configure a DepthDetector for usage with Vision-based goals"""
         timeout = 0.0
         # Get the depth image transform if the input is provided
         if self.in_topic_name(TopicsKeys.DEPTH_CAM_INFO):
             while (
-                not self.depth_tf_listener.got_transform or not self._depth_image_info
+                not (depth_tf := self._depth_tf_listener)
+                or not depth_tf.got_transform
+                or not self._depth_image_info
             ) and timeout <= self.config.topic_subscription_timeout:
                 # Depth image cam info
                 if not self._depth_image_info:
@@ -740,9 +753,12 @@ class Planner(Component):
             )
             return None
 
-        if not self.depth_tf_listener.got_transform:
+        depth_tf = self._depth_tf_listener
+        if not depth_tf or not depth_tf.got_transform:
             self.get_logger().error(
-                f"Could not obtain transformation between the Depth camera frame '{self.depth_tf_listener.config.source_frame}' to the robot body frame '{self.depth_tf_listener.config.goal_frame}'"
+                "Could not obtain transformation between the Depth camera frame "
+                f"'{depth_tf.config.source_frame if depth_tf else 'unknown'}' to the "
+                f"robot body frame '{self.config.frames.robot_base}'"
             )
             return None
 
@@ -758,8 +774,8 @@ class Planner(Component):
 
         return DepthDetector(
             depth_range=self.config.depth_range,
-            camera_in_body_translation=self.depth_tf_listener.translation,
-            camera_in_body_rotation=self.depth_tf_listener.rotation,
+            camera_in_body_translation=depth_tf.translation,
+            camera_in_body_rotation=depth_tf.rotation,
             focal_length=self._depth_image_info["focal_length"]
             if self._depth_image_info
             else None,

--- a/kompass/kompass/components/planner.py
+++ b/kompass/kompass/components/planner.py
@@ -258,9 +258,9 @@ class Planner(Component):
         self._depth_image_info: Optional[Dict] = None
 
         self.__robot = Robot(
-            robot_type=self.config.robot.model_type,
+            robot_type=self.robot.model_type,
             geometry_type=self.robot_geometry_type,
-            geometry_params=self.config.robot.geometry_params,
+            geometry_params=self.robot.geometry_params,
         )
 
         # Init OMPL with collision checking

--- a/kompass/kompass/components/planner.py
+++ b/kompass/kompass/components/planner.py
@@ -85,13 +85,19 @@ class Planner(Component):
     ```python
         from kompass.components import Planner, PlannerConfig
         from kompass.config import ComponentRunType
-        from kompass_core.models import RobotType, Robot, LinearCtrlLimits, AngularCtrlLimits
+        from kompass.robot import (
+            RobotConfig,
+            RobotType,
+            RobotGeometryType,
+            LinearCtrlLimits,
+            AngularCtrlLimits,
+        )
         import numpy as np
 
         # Configure your robot
         my_robot = RobotConfig(
                     model_type=RobotType.DIFFERENTIAL_DRIVE,
-                    geometry_type=RobotGeometry.Type.CYLINDER,
+                    geometry_type=RobotGeometryType.CYLINDER,
                     geometry_params=np.array([0.1, 0.3]),
                     ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=1.5, max_decel=2.5),
                     ctrl_omega_limits=AngularCtrlLimits(
@@ -253,7 +259,7 @@ class Planner(Component):
 
         self.__robot = Robot(
             robot_type=self.config.robot.model_type,
-            geometry_type=self.config.robot.geometry_type,
+            geometry_type=self.robot_geometry_type,
             geometry_params=self.config.robot.geometry_params,
         )
 

--- a/kompass/kompass/components/planner.py
+++ b/kompass/kompass/components/planner.py
@@ -156,6 +156,7 @@ class Planner(Component):
                 ComponentRunType.TIMED,
                 ComponentRunType.ACTION_SERVER,
                 ComponentRunType.EVENT,
+                ComponentRunType.SERVER,
             ],
             **kwargs,
         )

--- a/kompass/kompass/components/planner.py
+++ b/kompass/kompass/components/planner.py
@@ -417,7 +417,9 @@ class Planner(Component):
                         msg, callback=_cb, goal_index=_idx
                     )
                 )
-        if require_cam_info and not self.got_input(TopicsKeys.DEPTH_CAM_INFO):
+        if require_cam_info and not self.got_all_inputs(
+            inputs_to_check=[self.in_topic_name(TopicsKeys.DEPTH_CAM_INFO)]
+        ):
             raise ValueError(
                 f"At least one of the goal point callbacks is a {callback.__class__.__name__} which requires depth camera info input. Please provide a topic for {TopicsKeys.DEPTH_CAM_INFO} to ensure proper functionality."
             )

--- a/kompass/kompass/components/ros.py
+++ b/kompass/kompass/components/ros.py
@@ -99,33 +99,32 @@ def _get_allowed_number(
 def update_topics(
     topics_dict: Dict[TopicsKeys, Union[Topic, List[Topic], None]], **kwargs
 ) -> Dict[TopicsKeys, Union[Topic, List[Topic], None]]:
-    """Update a dictionary of topics given keyword arguments
+    """Get a new dictionary of topics updated with the given keyword arguments
+
+    The given dictionary is left unchanged
 
     :param topics_dict: Topic dictionary {topic_key_name: Topic}
     :type topics_dict: Dict[str, Topic]
     :return: Updated topics
     :rtype: Dict[str, Topic]
     """
-    if "allowed_config" in kwargs.keys():
-        allowed_config = kwargs["allowed_config"]
-        kwargs.pop("allowed_config")
-        # try:
-        for key, value in kwargs.items():
-            try:
-                topic_key = TopicsKeys(key)
-            except ValueError as e:
-                raise ValueError(
-                    f"Error updating topics: '{key}' is not a valid topic key. Allowed keys are: {list(allowed_config.keys())}"
-                ) from e
-            if _get_allowed_number(topic_key, value, allowed_config):
-                topics_dict[topic_key] = value
-    else:
-        for key, value in kwargs.items():
-            try:
-                topic_key = TopicsKeys(key)
-            except ValueError as e:
-                raise ValueError(
-                    f"Error updating topics: '{key}' is not a valid topic key. Allowed keys are: {list(allowed_config.keys())}"
-                ) from e
-            topics_dict[topic_key] = value
-    return topics_dict
+    allowed_config = kwargs.pop("allowed_config", None)
+    allowed_keys = (
+        list(allowed_config.keys()) if allowed_config else list(TopicsKeys)
+    )
+    # Copy the given topics (along with any list values) to keep it unchanged
+    updated_dict = {
+        key: list(value) if isinstance(value, list) else value
+        for key, value in topics_dict.items()
+    }
+    for key, value in kwargs.items():
+        try:
+            topic_key = TopicsKeys(key)
+        except ValueError as e:
+            raise ValueError(
+                f"Error updating topics: '{key}' is not a valid topic key. Allowed keys are: {allowed_keys}"
+            ) from e
+        if allowed_config and not _get_allowed_number(topic_key, value, allowed_config):
+            continue
+        updated_dict[topic_key] = value
+    return updated_dict

--- a/kompass/kompass/components/utils.py
+++ b/kompass/kompass/components/utils.py
@@ -2,7 +2,6 @@ import numpy as np
 from typing import List, Optional, Tuple, Union
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry
-from kompass_core.datatypes import LaserScanData, PointCloudData
 from kompass_core.models import RobotState
 
 from kompass_interfaces.msg import TwistArray

--- a/kompass/kompass/config.py
+++ b/kompass/kompass/config.py
@@ -1,27 +1,22 @@
 """Configuration classes for a Component and a robot in Kompass"""
 
-import math
-from typing import Union
-
-import numpy as np
 import ros_sugar.config.base_validators as BaseValidators
 from ros_sugar.config.base_config import (
     _convert_logging_severity_to_str,
     LoggingSeverity,
 )
-from attrs import Factory, define, field
-from kompass_core.models import (
-    AngularCtrlLimits,
-    LinearCtrlLimits,
-    RobotGeometry,
-    RobotType,
-)
+from attrs import define, field
 from ros_sugar.config import (
+    AngularCtrlLimits,
     BaseAttrs,
     BaseComponentConfig,
     BaseConfig,
     ComponentRunType,
+    LinearCtrlLimits,
+    RobotConfig,
     RobotFrames,
+    RobotGeometryType,
+    RobotType,
 )
 
 __all__ = [
@@ -30,86 +25,13 @@ __all__ = [
     "BaseConfig",
     "ComponentRunType",
     "BaseComponentConfig",
+    "RobotConfig",
     "RobotFrames",
+    "RobotType",
+    "RobotGeometryType",
+    "LinearCtrlLimits",
+    "AngularCtrlLimits",
 ]
-
-
-@define(kw_only=True)
-class RobotConfig(BaseAttrs):
-    """
-    Class for robot configuration (type, model, limitations, etc.)
-
-    ```{list-table}
-    :widths: 10 20 70
-    :header-rows: 1
-
-    * - Name
-      - Type, Default
-      - Description
-
-    * - **model_type**
-      - [RobotType](https://github.com/automatika-robotics/kompass-core/blob/main/src/kompass_core/models.py#L1095) | str, `ACKERMANN`
-      - Robot motion model type
-
-    * - **geometry_type**
-      - [RobotGeometry.Type](https://github.com/automatika-robotics/kompass-core/blob/main/src/kompass_core/models.py#L643) | str, `CYLINDER`
-      - Robot 3D geometry shape type
-
-    * - **geometry_type**
-      - `np.ndarray`, `[0.2, 1.0]`
-      - Robot 3D geometry shape parameters
-
-    * - **ctrl_vx_limits**
-      - [LinearCtrlLimits](https://github.com/automatika-robotics/kompass-core/blob/main/src/kompass_core/models.py#L1153)
-      - Forward linear velocity (x-direction) control limits parameters
-
-    * - **ctrl_omega_limits**
-      - [AngularCtrlLimits](https://github.com/automatika-robotics/kompass-core/blob/main/src/kompass_core/models.py#L1168)
-      - Angular velocity control limits parameters
-
-    * - **ctrl_vy_limits**
-      - [LinearCtrlLimits](https://github.com/automatika-robotics/kompass-core/blob/main/src/kompass_core/models.py#L1153)
-      - Lateral linear velocity (y-direction) control limits parameters
-
-    ```
-    """
-
-    # Robot Motion Model Type
-    model_type: Union[str, RobotType] = field(
-        default=RobotType.ACKERMANN,
-        converter=lambda value: RobotType.to_str(value),
-        validator=BaseValidators.in_(RobotType.values()),
-    )
-
-    # Geometry
-    geometry_type: Union[str, RobotGeometry.Type] = field(
-        default=RobotGeometry.Type.CYLINDER,
-        converter=lambda value: RobotGeometry.Type.from_str(value),
-    )
-    geometry_params: np.ndarray = field(default=np.array([0.2, 1.0]))
-
-    # Control limits
-    ctrl_vx_limits: LinearCtrlLimits = field(
-        default=LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0)
-    )
-    ctrl_omega_limits: AngularCtrlLimits = field(
-        default=AngularCtrlLimits(
-            max_vel=5.0, max_steer=math.pi, max_acc=10.0, max_decel=10.0
-        )
-    )
-    ctrl_vy_limits: LinearCtrlLimits = field(
-        default=LinearCtrlLimits(max_vel=0.0, max_acc=0.0, max_decel=0.0)
-    )  # Default to ackermann robot
-
-    @geometry_params.validator
-    def validate_params(self, _, value):
-        """
-        Validates geometry parameters against geometry type
-        """
-        if not RobotGeometry.is_valid_parameters(self.geometry_type, value):
-            raise ValueError(
-                f"Robot geometry parameters '{value}' are incompatible with given robot geometry {self.geometry_type}. Requires '{RobotGeometry.ParamsLength[self.geometry_type].value}' strictly positive parameters"
-            )
 
 
 @define(kw_only=True)
@@ -124,10 +46,6 @@ class ComponentConfig(BaseComponentConfig):
     * - Name
       - Type, Default
       - Description
-
-    * - **robot**
-      - RobotConfig, `RobotConfig()`
-      - Robot configuration parameters. See [RobotConfig](#kompass.config.RobotConfig) class for details.
 
     * - **topic_subscription_timeout**
       - float, `20.0`
@@ -146,10 +64,6 @@ class ComponentConfig(BaseComponentConfig):
       - Debug level for the component core algorithm
     ```
     """
-
-    # Robot config
-    robot: RobotConfig = field(default=Factory(RobotConfig))
-
     topic_subscription_timeout: float = field(
         default=5.0, validator=BaseValidators.in_range(min_value=1e-3, max_value=1e9)
     )

--- a/kompass/kompass/config.py
+++ b/kompass/kompass/config.py
@@ -1,7 +1,6 @@
 """Configuration classes for a Component and a robot in Kompass"""
 
 import math
-import warnings
 from typing import Union
 
 import numpy as np
@@ -22,6 +21,7 @@ from ros_sugar.config import (
     BaseComponentConfig,
     BaseConfig,
     ComponentRunType,
+    RobotFrames,
 )
 
 __all__ = [
@@ -30,75 +30,8 @@ __all__ = [
     "BaseConfig",
     "ComponentRunType",
     "BaseComponentConfig",
+    "RobotFrames",
 ]
-
-
-def _warn_if_optical_frame(_, attribute, value):
-    """Warn when an RGB/depth camera frame name looks like a ROS optical frame.
-
-    The ``rgb`` and ``depth`` fields are expected to refer to the *physical*
-    camera link (e.g. ``camera_link``, ``camera_depth_link``), not the
-    z-forward optical frame typically published by ROS drivers as
-    ``*_optical_frame``. Using the optical frame here usually means the
-    camera→body transform will be off by the link↔optical rotation.
-    """
-    if value and "optical" in value.lower():
-        warnings.warn(
-            f"RobotFrames.{attribute.name}='{value}' looks like a ROS optical "
-            f"frame; this field expects the physical camera link (e.g. "
-            f"'camera_link'), not the optical frame. Check that the camera "
-            f"driver publishes the link you intended.",
-            UserWarning,
-            stacklevel=3,
-        )
-
-
-@define(kw_only=True)
-class RobotFrames(BaseAttrs):
-    """
-    Class for robot coordinate frames configuration
-    ```{list-table}
-    :widths: 10 20 70
-    :header-rows: 1
-
-    * - Frame
-      - Default
-      - Description
-
-    * - **world**
-      - "map"
-      - Reference world frame
-
-    * - **robot_base**
-      - "base_link"
-      - Robot base link frame
-
-    * - **odom**
-      - "odom"
-      - Robot odometry frame
-
-    * - **scan**
-      - "base_link"
-      - LaseScan sensor base frame
-
-    * - **rgb**
-      - "camera_link"
-      - RGB camera base frame
-
-    * - **depth**
-      - "camera_depth_link"
-      - Depth camera base frame
-
-    ```
-    """
-
-    robot_base: str = field(default="base_link")
-    odom: str = field(default="odom")
-    world: str = field(default="map")
-    scan: str = field(default="base_link")
-    rgb: str = field(default="camera_link", validator=_warn_if_optical_frame)
-    depth: str = field(default="camera_depth_link", validator=_warn_if_optical_frame)
-    point_cloud: str = field(default="point_cloud_link")
 
 
 @define(kw_only=True)
@@ -196,10 +129,6 @@ class ComponentConfig(BaseComponentConfig):
       - RobotConfig, `RobotConfig()`
       - Robot configuration parameters. See [RobotConfig](#kompass.config.RobotConfig) class for details.
 
-    * - **frames**
-      - RobotFrames, `RobotFrames()`
-      - Robot TF frames configuration. See [RobotFrames](#kompass.config.RobotFrames) class for details.
-
     * - **topic_subscription_timeout**
       - float, `20.0`
       - Timeout when waiting for an input topic to become available (s)
@@ -220,9 +149,6 @@ class ComponentConfig(BaseComponentConfig):
 
     # Robot config
     robot: RobotConfig = field(default=Factory(RobotConfig))
-
-    # Robot Frames
-    frames: RobotFrames = field(default=Factory(RobotFrames))
 
     topic_subscription_timeout: float = field(
         default=5.0, validator=BaseValidators.in_range(min_value=1e-3, max_value=1e9)

--- a/kompass/kompass/config.py
+++ b/kompass/kompass/config.py
@@ -48,15 +48,11 @@ class ComponentConfig(BaseComponentConfig):
       - Description
 
     * - **topic_subscription_timeout**
-      - float, `20.0`
+      - float, `5.0`
       - Timeout when waiting for an input topic to become available (s)
 
     * - **topic_try_wait_timeout**
-      - float, `0.1`
-      - Time interval when waiting for input topic to become available (s)
-
-    * - **topic_try_wait_timeout**
-      - float, `0.1`
+      - float, `0.05`
       - Time interval when waiting for input topic to become available (s)
 
     * - **core_log_level**

--- a/kompass/kompass/data_types.py
+++ b/kompass/kompass/data_types.py
@@ -20,7 +20,7 @@ from geometry_msgs.msg import (
     PoseStamped as ROSPoseStamped,
     TwistStamped as ROSTwistStamped,
 )
-from kompass_core.datatypes import LaserScanData
+from ros_sugar.io import LaserScanData
 from nav_msgs.msg import Odometry as ROSOdometry
 from nav_msgs.msg import Path as ROSPath
 from kompass_core.models import RobotState

--- a/kompass/kompass/robot.py
+++ b/kompass/kompass/robot.py
@@ -18,3 +18,38 @@ __all__ = [
     "LinearCtrlLimits",
     "AngularCtrlLimits",
 ]
+
+
+# Backward compatibility: Names this module used to re-export from kompass_core.
+_MOVED = {
+    "RobotGeometry": (
+        "Declare the shape with 'RobotGeometryType' instead:\n"
+        "    from kompass.robot import RobotConfig, RobotGeometryType\n"
+        "    RobotConfig(geometry_type=RobotGeometryType.CYLINDER, ...)\n"
+        "'RobotGeometry.Type' no longer works here.\n"
+        "If you genuinely need the geometry helpers (get_radius, get_height, "
+        "get_footprint), import them from 'kompass_core.models'."
+    ),
+    "RobotCtrlLimits": (
+        "Declare the velocity envelope on the robot description instead:\n"
+        "    from kompass.robot import RobotConfig, LinearCtrlLimits, AngularCtrlLimits\n"
+        "    RobotConfig(ctrl_vx_limits=LinearCtrlLimits(...), "
+        "ctrl_omega_limits=AngularCtrlLimits(...), ...)\n"
+        "If you are writing a component and need that type directly, import it "
+        "from 'kompass_core.models'."
+    ),
+}
+
+
+def __getattr__(name: str):
+    """Point at the new spelling for names this module no longer exports.
+
+    ``ImportError`` rather than ``AttributeError`` on purpose: a ``from ...
+    import ...`` statement discards an ``AttributeError`` and replaces it with
+    its own generic message, which would throw this guidance away.
+    """
+    if name in _MOVED:
+        raise ImportError(
+            f"'{name}' is no longer part of 'kompass.robot'.\n\n{_MOVED[name]}"
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/kompass/kompass/robot.py
+++ b/kompass/kompass/robot.py
@@ -1,6 +1,5 @@
-# The robot description lives in Sugarcoat; kompass_core keeps the runtime
-# types that wrap the C++ library (control limits adapter, geometry math).
-from kompass_core.models import RobotCtrlLimits, RobotGeometry
+# The robot description a recipe declares.
+
 from .config import (
     RobotConfig,
     RobotFrames,
@@ -14,8 +13,6 @@ from .config import (
 __all__ = [
     "RobotConfig",
     "RobotFrames",
-    "RobotCtrlLimits",
-    "RobotGeometry",
     "RobotType",
     "RobotGeometryType",
     "LinearCtrlLimits",

--- a/kompass/kompass/robot.py
+++ b/kompass/kompass/robot.py
@@ -1,11 +1,14 @@
-from kompass_core.models import (
-    RobotCtrlLimits,
-    RobotGeometry,
+# The robot description lives in Sugarcoat; kompass_core keeps the runtime
+# types that wrap the C++ library (control limits adapter, geometry math).
+from kompass_core.models import RobotCtrlLimits, RobotGeometry
+from .config import (
+    RobotConfig,
+    RobotFrames,
     RobotType,
+    RobotGeometryType,
     LinearCtrlLimits,
     AngularCtrlLimits,
 )
-from .config import RobotConfig, RobotFrames
 
 
 __all__ = [
@@ -14,6 +17,7 @@ __all__ = [
     "RobotCtrlLimits",
     "RobotGeometry",
     "RobotType",
+    "RobotGeometryType",
     "LinearCtrlLimits",
     "AngularCtrlLimits",
 ]

--- a/kompass/params/turtlebot3.json
+++ b/kompass/params/turtlebot3.json
@@ -2,9 +2,7 @@
     "/**": {
         "frames": {
             "robot_base": "base_link",
-            "odom": "map",
-            "world": "map",
-            "scan": "LDS-01"
+            "world": "map"
         }
     },
     "mapper": {

--- a/kompass/params/turtlebot3.yaml
+++ b/kompass/params/turtlebot3.yaml
@@ -2,9 +2,7 @@
 
   frames:
     robot_base: "base_link"
-    odom: "map"
     world: "map"
-    scan: "LDS-01"
 
 mapper:
   loop_rate: 10.0

--- a/kompass/recipes/turtlebot3.py
+++ b/kompass/recipes/turtlebot3.py
@@ -3,7 +3,7 @@ import os
 from kompass.robot import (
     AngularCtrlLimits,
     LinearCtrlLimits,
-    RobotGeometry,
+    RobotGeometryType,
     RobotType,
     RobotConfig,
 )
@@ -39,7 +39,7 @@ def kompass_bringup():
     # Setup your robot configuration
     my_robot = RobotConfig(
         model_type=RobotType.DIFFERENTIAL_DRIVE,
-        geometry_type=RobotGeometry.Type.CYLINDER,
+        geometry_type=RobotGeometryType.CYLINDER,
         geometry_params=np.array([0.08, 0.3]),
         ctrl_vx_limits=LinearCtrlLimits(max_vel=0.4, max_acc=1.5, max_decel=2.5),
         ctrl_omega_limits=AngularCtrlLimits(

--- a/kompass/recipes/turtlebot3.py
+++ b/kompass/recipes/turtlebot3.py
@@ -6,7 +6,6 @@ from kompass.robot import (
     RobotGeometry,
     RobotType,
     RobotConfig,
-    RobotFrames,
 )
 from kompass.control import ControllersID, MapConfig
 from automatika_ros_sugar.msg import ComponentStatus
@@ -23,11 +22,13 @@ from kompass.components import (
     MapServerConfig,
     TopicsKeys,
 )
-from kompass.ros import Topic, Launcher, Event, Action, actions
+from kompass.ros import Topic, Launcher, Event, Action, actions, ServiceClientConfig
 
 from ament_index_python.packages import (
     get_package_share_directory,
 )
+
+from kompass_interfaces.srv import StartPathRecording
 
 
 def kompass_bringup():
@@ -50,6 +51,7 @@ def kompass_bringup():
     planner_config = PlannerConfig(loop_rate=1.0)
     planner = Planner(component_name="planner", config=planner_config)
     planner.run_type = "ActionServer"  # Run the planner as an ActionServer to receive goals from the UI or other components
+
     clicked_point_topic = Topic(name="/clicked_point", msg_type="PointStamped")
     planner.inputs(goal_point=clicked_point_topic)
 
@@ -80,12 +82,12 @@ def kompass_bringup():
 
     # Configure a Local Mapper
     local_mapper_config = LocalMapperConfig(
+        loop_rate=5,
         map_params=MapConfig(
             width=4.0,
             height=4.0,
             resolution=0.1,
-            max_points_per_line=256,
-        )
+        ),
     )
     local_mapper = LocalMapper(component_name="mapper", config=local_mapper_config)
     local_mapper.inputs(sensor_data=Topic(name="/scan", msg_type="LaserScan"))
@@ -126,8 +128,8 @@ def kompass_bringup():
         args=(
             clicked_point_topic.msg.point.x,
             clicked_point_topic.msg.point.y,
-            0.05,    # Goal distance tolerance
-            0.2,   # Goal angle tolerance (in radians)
+            0.05,  # Goal distance tolerance
+            0.2,  # Goal angle tolerance (in radians)
         ),
     )
 
@@ -142,29 +144,35 @@ def kompass_bringup():
 
     # Setup the launcher
     launcher = Launcher(config_file=config_file)
-
     # Add Kompass components
     launcher.add_pkg(
         components=[map_server, controller, planner, driver, local_mapper],
         events_actions=events_actions,
         multiprocessing=True,
-        package_name="kompass"      # ROS2 package name for the Kompass components
+        package_name="kompass",  # ROS2 package name for the Kompass components
     )
 
     # Get odom from localizer filtered odom for all components
-    odom_topic = Topic(name="/odometry/filtered", msg_type="Odometry")      # Robot odometry topic published in global frame (map) by the localizer
+    odom_topic = Topic(
+        name="/odometry/filtered", msg_type="Odometry"
+    )  # Robot odometry topic published in global frame (map) by the localizer
     launcher.inputs(location=odom_topic)
 
     # Set the robot config for all components
     launcher.robot = my_robot
-    launcher.frames = RobotFrames(
-        world="map", odom="map", scan="LDS-01"
-    )
+
     # Enable the UI
     # Inputs: Planner action server
     # Outputs: Static Map, Global Plan, Robot Odometry
+    start_path_recording = ServiceClientConfig(
+        name=f"{planner.node_name}/start_path_recording", srv_type=StartPathRecording
+    )
     launcher.enable_ui(
-        inputs=[planner.ui_main_action_input],
+        inputs=[
+            planner.ui_main_action_input,
+            clicked_point_topic,
+            start_path_recording,
+        ],
         outputs=[
             map_server.get_out_topic(TopicsKeys.GLOBAL_MAP),
             odom_topic,

--- a/kompass/test/test_path_control.py
+++ b/kompass/test/test_path_control.py
@@ -17,7 +17,7 @@ from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from kompass_core.datatypes import LaserScanData
+from ros_sugar.io import LaserScanData, PointCloudData
 from kompass_core.models import RobotState
 
 from kompass.components.controller import (
@@ -208,8 +208,23 @@ class TestPathControlStatus:
         c._path_control()
 
         kwargs = _get_mangled(c, "path_controller").loop_step.call_args.kwargs
-        assert kwargs["laser_scan"] is scan
-        assert kwargs["point_cloud"] is None
+        assert kwargs["ranges"] is scan.ranges
+        assert kwargs["angles"] is scan.angles
+        assert kwargs["points"] is None
+        assert kwargs["local_map"] is None
+
+    def test_direct_sensor_routes_point_cloud(self):
+        c = make_path_controller_stub()
+        c.config.use_direct_sensor = True
+        cloud = MagicMock(spec=PointCloudData)
+        c.sensor_data = cloud
+
+        c._path_control()
+
+        kwargs = _get_mangled(c, "path_controller").loop_step.call_args.kwargs
+        assert kwargs["points"] is cloud.xyz
+        assert kwargs["ranges"] is None
+        assert kwargs["angles"] is None
         assert kwargs["local_map"] is None
 
     def test_non_direct_sensor_routes_local_map(self):
@@ -223,8 +238,9 @@ class TestPathControlStatus:
         kwargs = _get_mangled(c, "path_controller").loop_step.call_args.kwargs
         assert kwargs["local_map"] is c.local_map
         assert kwargs["local_map_resolution"] == 0.05
-        assert kwargs["laser_scan"] is None
-        assert kwargs["point_cloud"] is None
+        assert kwargs["ranges"] is None
+        assert kwargs["angles"] is None
+        assert kwargs["points"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/kompass/test/test_path_control.py
+++ b/kompass/test/test_path_control.py
@@ -75,7 +75,6 @@ def make_path_controller_stub(**overrides) -> Controller:
     c.config.topic_subscription_timeout = 0.01
     c.config.loop_rate = 1000.0
     c.config.debug = False
-    c.config.prediction_horizon = 1.0
     # The algorithm setter on the real config is a converter; stub the enum directly
     from kompass_core.control import ControllersID
     c.config.algorithm = ControllersID.DWA

--- a/kompass/test/test_planner.py
+++ b/kompass/test/test_planner.py
@@ -56,7 +56,6 @@ def make_planner_stub(**overrides) -> Planner:
     p.config = MagicMock()
     p.config.frames = MagicMock()
     p.config.frames.world = "map"
-    p.config.frames.odom = "odom"
     p.config.distance_tolerance = 0.1
     p.config.loop_rate = 1000.0
     p.config.topic_subscription_timeout = 0.01

--- a/kompass/test/test_vision_tracking.py
+++ b/kompass/test/test_vision_tracking.py
@@ -34,6 +34,18 @@ from kompass_core.datatypes import LaserScanData
 # ---------------------------------------------------------------------------
 
 
+class _StubController(Controller):
+    """Controller whose TF listeners are plain writable attributes.
+
+    ``odom_tf_listener`` is a property on the real component that looks the
+    transform up through the node's shared TF buffer. These tests exercise
+    state handling, not TF plumbing, so the class attribute below shadows the
+    property and lets each test inject a mock listener directly.
+    """
+
+    odom_tf_listener = None
+
+
 def make_controller_stub(**overrides) -> Controller:
     """Build a bare Controller (with attached VisionFollower) and mock dependencies.
 
@@ -42,7 +54,7 @@ def make_controller_stub(**overrides) -> Controller:
     state (``_vision_controller``, ``_tracked_center``, detections, depth
     image) lives on ``c._vision_follower`` rather than on the controller.
     """
-    c = object.__new__(Controller)
+    c = object.__new__(_StubController)
 
     # Threading / queues
     c._main_goal_lock = threading.Lock()
@@ -64,13 +76,12 @@ def make_controller_stub(**overrides) -> Controller:
     c.config.topic_subscription_timeout = 0.1
     c.config.loop_rate = 100.0
     c.config.frames = MagicMock()
-    c.config.frames.odom = "odom"
-    c.config.frames.world = "odom"  # same-frame -> no TF needed
+    c.config.frames.world = "map"
 
-    # TF listener (property reads self._odom_tf_listener lazily; bypass by setting it directly)
+    # TF listener (the real property is shadowed by _StubController)
     tf_listener = MagicMock()
     tf_listener.transform = MagicMock()
-    c._odom_tf_listener = tf_listener
+    c.odom_tf_listener = tf_listener
 
     # IO fakes
     c.get_callback = MagicMock(return_value=None)
@@ -183,10 +194,9 @@ class TestTerminateVisionAction:
 
 class TestUpdateStateNonBlocking:
     def test_reads_state_without_transform_when_tf_missing(self):
-        """Non-blocking with frames differing and no TF: skip the wait loop and
-        read the raw odom-frame state (no transformation applied)."""
+        """Non-blocking with no TF available: skip the wait loop and read the
+        raw location-frame state (no transformation applied)."""
         c = make_controller_stub()
-        c.config.frames.odom = "odom"
         c.config.frames.world = "map"
         c.odom_tf_listener.transform = None
         state_cb = MagicMock()
@@ -211,7 +221,6 @@ class TestUpdateStateNonBlocking:
 
     def test_uses_cached_transform_when_available(self):
         c = make_controller_stub()
-        c.config.frames.odom = "odom"
         c.config.frames.world = "map"
         cached_tf = object()
         c.odom_tf_listener.transform = cached_tf
@@ -229,11 +238,13 @@ class TestUpdateStateNonBlocking:
         )
         assert c.robot_state == "STATE"
 
-    def test_same_frame_bypasses_tf_entirely(self):
+    def test_no_location_message_yet_reads_without_transform(self):
+        """Before the first location message the source frame is unknown, so
+        there is no listener at all: read the state untransformed rather than
+        blocking on a lookup that cannot be built yet."""
         c = make_controller_stub()
-        c.config.frames.odom = "odom"
-        c.config.frames.world = "odom"
-        c.odom_tf_listener.transform = None  # irrelevant
+        c.config.frames.world = "map"
+        c.odom_tf_listener = None
         state_cb = MagicMock()
         state_cb.get_output.return_value = "STATE"
         c.get_callback = MagicMock(
@@ -243,7 +254,9 @@ class TestUpdateStateNonBlocking:
         )
 
         c._update_state(block=False)
-        state_cb.get_output.assert_called_once_with(get_front=True, clear_last=True)
+        state_cb.get_output.assert_called_once_with(
+            transformation=None, get_front=True, clear_last=True
+        )
         assert c.robot_state == "STATE"
 
 

--- a/kompass/test/test_vision_tracking.py
+++ b/kompass/test/test_vision_tracking.py
@@ -26,7 +26,7 @@ from kompass.components.controller import (
 )
 from kompass.components._vision_follower import VisionFollower
 from kompass.components.defaults import TopicsKeys
-from kompass_core.datatypes import LaserScanData
+from ros_sugar.io import LaserScanData
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Companion to [Sugarcoat PR 58](https://github.com/automatika-robotics/sugarcoat/pull/58). Kompass hands `RobotConfig`, `RobotFrames` and the shared callbacks up to Sugarcoat, and stops asking recipes to name sensor frames.

## Recipes no longer declare sensor frames

Before:

```python
launcher.frames = RobotFrames(
    robot_base="base_link", world="map", odom="map",
    scan="LDS-01", rgb="camera_link", depth="camera_link",
)
```

After:

```python
launcher.frames = RobotFrames(robot_base="base_link", world="map")
```

Sensor frames come from each message's `header.frame_id`, so a component states the frame its algorithm needs and the data arrives already transformed. 

## Fixes

- **An Ackermann robot could attempt `rotate_in_place`.** `self.robot.model_type == RobotType.ACKERMANN` was **always `False`**. Fixed by the upstreamed `StrEnum`.
- **`_update_state` could deadlock on non-stamped location types.** `ROBOT_LOCATION` accepts a bare `Pose`, which has no header and therefore no frame. The wait now keys on the message rather than the frame, and handles the frameless case explicitly instead of blocking until timeout.


## Migration

- Kompass's local `LaserScanCallback` / `PointCloudCallback` (in `callbacks.py`), now upstreamed.
- Recipes must drop `odom`, `scan`, `rgb`, `depth` and `point_cloud` from `RobotFrames`.
- `RobotConfig` construction is unchanged. `kompass_core` enums and control-limit classes are still accepted.