### PR TITLE
Align component input frames with the kompass-core frame contract

### DIFF
--- a/kompass/kompass/__init__.py
+++ b/kompass/kompass/__init__.py
@@ -6,7 +6,7 @@ from importlib.metadata import version, PackageNotFoundError
 from packaging import version as pkg_version
 
 # Minimum required versions
-MIN_KOMPASS_CORE_VERSION = "0.8.2"
+MIN_KOMPASS_CORE_VERSION = "0.8.3"
 MIN_SUGARCOAT_VERSION = "0.8.0"
 
 

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -586,20 +586,12 @@ class Component(BaseComponent):
         goal_frame: Optional[str] = None,
         idx: int = 0,
     ) -> Tuple[bool, Optional[TransformStamped]]:
-        """Resolve, right now, the transform taking an input into a given frame.
+        """Resolve, at call time, the transform taking an input into a given frame.
 
-        The transform stored on a callback is refreshed only when a message
-        arrives, so an input published before its TF came up keeps a stale empty
-        transform for as long as nothing republishes. Looking the transform up
-        here instead means a late TF is picked up on the next read.
-
-        Unlike ``input_tf_listener`` this answers the question a consumer
-        actually has -- can I use this data in the frame I need, and with what
-        transform -- separating "already in the goal frame" from "cannot be put
-        there yet", so data is never quietly used in the frame it arrived in.
-
-        Pass the returned transform to the callback's ``get_output`` to have the
-        data delivered in the goal frame.
+        Unlike the transform cached on a callback (refreshed only on message
+        arrival), this looks the TF up live, so a TF that came up late is still
+        picked up. Pass the returned transform to the callback's ``get_output``
+        to deliver the data in the goal frame.
 
         :param topic_key: Key of the component input topic
         :type topic_key: TopicsKeys

--- a/kompass/kompass/components/component.py
+++ b/kompass/kompass/components/component.py
@@ -3,6 +3,7 @@ import json
 from typing import Dict, List, Optional, Union, Tuple
 from ros_sugar.core import ComponentFallbacks, BaseComponent
 from ros_sugar.tf import TFListener
+from tf2_ros import TransformStamped
 from ros_sugar.io import Publisher, AllowedTopics
 
 from ..callbacks import GenericCallback
@@ -578,6 +579,54 @@ class Component(BaseComponent):
         return self.get_transform_listener(
             callback.frame_id, goal_frame, static_tf=static_tf
         )
+
+    def resolve_input_tf(
+        self,
+        topic_key: TopicsKeys,
+        goal_frame: Optional[str] = None,
+        idx: int = 0,
+    ) -> Tuple[bool, Optional[TransformStamped]]:
+        """Resolve, right now, the transform taking an input into a given frame.
+
+        The transform stored on a callback is refreshed only when a message
+        arrives, so an input published before its TF came up keeps a stale empty
+        transform for as long as nothing republishes. Looking the transform up
+        here instead means a late TF is picked up on the next read.
+
+        Unlike ``input_tf_listener`` this answers the question a consumer
+        actually has -- can I use this data in the frame I need, and with what
+        transform -- separating "already in the goal frame" from "cannot be put
+        there yet", so data is never quietly used in the frame it arrived in.
+
+        Pass the returned transform to the callback's ``get_output`` to have the
+        data delivered in the goal frame.
+
+        :param topic_key: Key of the component input topic
+        :type topic_key: TopicsKeys
+        :param goal_frame: Frame to deliver the data in, defaults to the
+            configured world frame
+        :type goal_frame: Optional[str]
+        :param idx: Index of the input, for keys bound to several topics
+        :type idx: int
+
+        :return: Whether the input can be delivered in the goal frame, and the
+            transform to ask for it with (None when none is needed)
+        :rtype: Tuple[bool, Optional[TransformStamped]]
+        """
+        goal = goal_frame or self.config.frames.world
+        callback = self.get_callback(topic_key, idx)
+        # No frame to reason about: nothing to look up and nothing to transform,
+        # so the data is taken as it arrived
+        if not callback or not callback.frame_id:
+            return True, None
+
+        if callback.frame_id == goal:
+            return True, None
+
+        tf_listener = self.get_transform_listener(callback.frame_id, goal)
+        if not tf_listener.got_transform:
+            return False, None
+        return True, tf_listener.transform
 
     def _wait_for_tf(self, tf_listener: TFListener, description: str = "") -> bool:
         """Block up to ``config.topic_subscription_timeout`` waiting for a

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -824,28 +824,71 @@ class Controller(Component):
             TopicsKeys.SPATIAL_SENSOR, self.config.frames.robot_base, static_tf=True
         )
 
-    def _update_sensor_data(self) -> None:
+    def _update_sensor_data(self) -> bool:
         """Update sensor data from the sensor callback.
 
-        A laser scan is left in the sensor frame; a point cloud is delivered in
-        the world frame by its callback. See ``init_variables`` for why.
+        A laser scan is left in the sensor frame, since the core places it from
+        the mount pose. Cartesian obstacles -- a point cloud or local map cells
+        -- are asked for in the world frame, and dropped rather than handed over
+        unconverted if they cannot be put there.
+
+        :return: Whether the obstacle input could be delivered in the frame the
+            core expects. False leaves the controller without obstacles for this
+            step rather than placing them wrongly
+        :rtype: bool
         """
         if self.direct_sensor:
             self.local_map = None
             sensor_callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)
-            self.sensor_data = sensor_callback.get_output() if sensor_callback else None
-        else:
-            self.sensor_data = None
-            map_callback = self.get_callback(TopicsKeys.LOCAL_MAP)
-            if map_callback:
-                self.local_map: Optional[np.ndarray] = map_callback.get_output()
-                _metadata = map_callback.get_output(get_metadata=True)
-                self.local_map_resolution = (
-                    _metadata["resolution"] if _metadata else None
+            if not sensor_callback:
+                self.sensor_data = None
+                return True
+
+            if not isinstance(sensor_callback, PointCloudCallback):
+                # A laser scan belongs in the sensor frame
+                self.sensor_data = sensor_callback.get_output()
+                return True
+
+            deliverable, transform = self.resolve_input_tf(TopicsKeys.SPATIAL_SENSOR)
+            if not deliverable:
+                self.sensor_data = None
+                self.get_logger().error(
+                    f"Point cloud is published in the '{sensor_callback.frame_id}' "
+                    f"frame but its transform to '{self.config.frames.world}' is "
+                    "not available -> dropping it rather than placing obstacles "
+                    "in the wrong frame",
+                    throttle_duration_sec=5.0,
                 )
-            else:
-                self.local_map = None
-                self.local_map_resolution = None
+                return False
+            self.sensor_data = sensor_callback.get_output(transformation=transform)
+            return True
+
+        self.sensor_data = None
+        map_callback = self.get_callback(TopicsKeys.LOCAL_MAP)
+        if not map_callback:
+            self.local_map = None
+            self.local_map_resolution = None
+            return True
+
+        # Metadata is read off the message itself, so it needs no transform
+        _metadata = map_callback.get_output(get_metadata=True)
+        self.local_map_resolution = _metadata["resolution"] if _metadata else None
+
+        deliverable, transform = self.resolve_input_tf(TopicsKeys.LOCAL_MAP)
+        if not deliverable:
+            self.local_map = None
+            self.get_logger().error(
+                f"Local map is published in the '{map_callback.frame_id}' frame "
+                f"but its transform to '{self.config.frames.world}' is not "
+                "available -> dropping it rather than placing obstacles in the "
+                "wrong frame",
+                throttle_duration_sec=5.0,
+            )
+            return False
+        self.local_map: Optional[np.ndarray] = map_callback.get_output(
+            transformation=transform
+        )
+        return True
 
     def _read_robot_state(self) -> Optional[RobotState]:
         """Helper method to read the robot state from the location topic"""
@@ -869,10 +912,7 @@ class Controller(Component):
             yet available the update is skipped for this tick.
         """
         if self.config._mode == ControllerMode.PATH_FOLLOWER:
-            plan_callback = self.get_callback(TopicsKeys.GLOBAL_PLAN)
-            self.plan: Optional[Path] = (
-                plan_callback.get_output() if plan_callback else None
-            )
+            self.plan: Optional[Path] = self._read_plan()
 
         # In LOCAL frame mode robot state is irrelevant: sensor data and
         # tracked targets are reasoned about robot-relative.
@@ -950,31 +990,30 @@ class Controller(Component):
         if plan_callback:
             plan_callback.on_callback_execute(self._set_path_to_controller)
 
-    def _plan_tf_available(self) -> bool:
-        """Whether the last global plan could be expressed in the world frame.
+    def _read_plan(self) -> Optional[Path]:
+        """Read the global plan, in the world frame the core tracks against.
 
-        :return: True if the plan is safe to hand to the core
-        :rtype: bool
+        The single place a plan is fetched, so every consumer gets the same
+        guarantee: either the plan is in the world frame, or there is no plan.
+
+        :return: The plan in the world frame, or None if there is none or it
+            cannot be brought there yet
+        :rtype: Optional[Path]
         """
         plan_callback = self.get_callback(TopicsKeys.GLOBAL_PLAN)
         if not plan_callback:
-            # No subscription to ask about the frame. That is the same
-            # not-knowing as a plan without a frame_id, so it is taken at face
-            # value rather than treated as a plan in the wrong frame
-            return True
-        plan_frame = plan_callback.frame_id
-        # A plan with no frame_id is taken at face value, matching how a
-        # headerless robot location message is handled
-        if not plan_frame or plan_frame == self.config.frames.world:
-            return True
-        if plan_callback.transformation:
-            return True
-        self.get_logger().error(
-            f"Global plan is published in the '{plan_frame}' frame but its "
-            f"transform to '{self.config.frames.world}' is not available "
-            "-> dropping this plan"
-        )
-        return False
+            return None
+
+        deliverable, transform = self.resolve_input_tf(TopicsKeys.GLOBAL_PLAN)
+        if not deliverable:
+            self.get_logger().error(
+                f"Global plan is published in the '{plan_callback.frame_id}' "
+                f"frame but its transform to '{self.config.frames.world}' is "
+                "not available -> dropping this plan",
+                throttle_duration_sec=5.0,
+            )
+            return None
+        return plan_callback.get_output(transformation=transform)
 
     def _set_path_to_controller(self, output, **_) -> None:
         """
@@ -983,14 +1022,22 @@ class Controller(Component):
         The plan arrives already expressed in the world frame: the component
         asks for this input in ``frames.world`` and the callback transforms it.
         """
-        if output is None or not self._plan_tf_available():
+        deliverable, _ = self.resolve_input_tf(TopicsKeys.GLOBAL_PLAN)
+        if output is None or not deliverable:
+            self.get_logger().error(
+                "Global plan cannot be expressed in the "
+                f"'{self.config.frames.world}' frame -> dropping this plan",
+                throttle_duration_sec=5.0,
+            )
             return
+        plan = output
+        self.plan = plan
         self._reached_end = False
         if self._path_controller:
-            self._path_controller.set_path(global_path=output)
-        if len(output.poses) > 1:
+            self._path_controller.set_path(global_path=plan)
+        if len(plan.poses) > 1:
             self._goal_point = RobotState(
-                x=output.poses[-1].pose.position.x, y=output.poses[-1].pose.position.y
+                x=plan.poses[-1].pose.position.x, y=plan.poses[-1].pose.position.y
             )
         else:
             self._goal_point = None
@@ -1127,9 +1174,16 @@ class Controller(Component):
             proximity_sensor_rotation_to_robot=sensor_tf.rotation,
         )
         self._sensor_mount_pose_set = True
-        # The rebuild dropped the path the previous object was tracking
+        # The rebuild dropped the path the previous object was tracking.
+        # `self.plan` is the guarded world-frame read refreshed by
+        # `_update_state` just above, so this cannot install a wrong-frame path
         if self.plan is not None:
             self._path_controller.set_path(global_path=self.plan)
+        else:
+            self.get_logger().warning(
+                "No global plan available while applying the scan mount pose "
+                "-> the rebuilt controller starts without a path"
+            )
 
     def _stop_robot(self):
         """
@@ -1206,8 +1260,12 @@ class Controller(Component):
             return PathControlStatus.IDLE
 
         self._update_state(block=True)
-        self._update_sensor_data()
+        obstacles_deliverable = self._update_sensor_data()
         self._apply_sensor_mount_pose()
+
+        if not obstacles_deliverable:
+            # Obstacles exist but could not be put in the frame the core reads
+            return PathControlStatus.WAITING_INPUTS
 
         if not self.robot_state:
             self.get_logger().warning(
@@ -1340,9 +1398,17 @@ class Controller(Component):
         # Note: This will automatically end the vision target tracking action if it is ongoing
         self.config._mode = ControllerMode.PATH_FOLLOWER
 
-        if not self._plan_tf_available():
+        deliverable, _ = self.resolve_input_tf(TopicsKeys.GLOBAL_PLAN)
+        if not deliverable:
+            self.get_logger().error(
+                "Global plan is not available in the world frame -> Aborting"
+            )
             goal_handle.abort()
             return result
+        # Refresh where possible: in ACTION_SERVER mode nothing has run
+        # _update_state yet, so `self.plan` may be stale at this point
+        if (_plan := self._read_plan()) is not None:
+            self.plan = _plan
         self._path_controller.set_path(self.plan)  # type: ignore
 
         self._reached_end: bool = False

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -298,6 +298,11 @@ class Controller(Component):
             )
         # Create subscribers
         for callback in self.callbacks.values():
+            # Callbacks are rebuilt above, so the resolvers behind
+            # transform_inputs_to have to be re-attached to the new ones.
+            # Frame handling applies to plugin-fed non-ROS inputs too
+            self._attach_transform_provider(callback.input_topic.name, callback)
+
             # Inputs bound to a non-ROS robot plugin transport are fed through
             # the feedback bus, not a ROS subscription
             if callback.input_topic.name in self._external_topics:
@@ -934,16 +939,44 @@ class Controller(Component):
         if plan_callback:
             plan_callback.on_callback_execute(self._set_path_to_controller)
 
-    def _set_path_to_controller(self, msg, **_) -> None:
+    def _plan_tf_available(self) -> bool:
+        """Whether the last global plan could be expressed in the world frame.
+
+        :return: True if the plan is safe to hand to the core
+        :rtype: bool
+        """
+        plan_callback = self.get_callback(TopicsKeys.GLOBAL_PLAN)
+        if not plan_callback:
+            return False
+        plan_frame = plan_callback.frame_id
+        # A plan with no frame_id is taken at face value, matching how a
+        # headerless robot location message is handled
+        if not plan_frame or plan_frame == self.config.frames.world:
+            return True
+        if plan_callback.transformation:
+            return True
+        self.get_logger().error(
+            f"Global plan is published in the '{plan_frame}' frame but its "
+            f"transform to '{self.config.frames.world}' is not available "
+            "-> dropping this plan"
+        )
+        return False
+
+    def _set_path_to_controller(self, output, **_) -> None:
         """
         Set a new plan to the controller/follower
+
+        The plan arrives already expressed in the world frame: the component
+        asks for this input in ``frames.world`` and the callback transforms it.
         """
+        if output is None or not self._plan_tf_available():
+            return
         self._reached_end = False
         if self._path_controller:
-            self._path_controller.set_path(global_path=msg)
-        if len(msg.poses) > 1:
+            self._path_controller.set_path(global_path=output)
+        if len(output.poses) > 1:
             self._goal_point = RobotState(
-                x=msg.poses[-1].pose.position.x, y=msg.poses[-1].pose.position.y
+                x=output.poses[-1].pose.position.x, y=output.poses[-1].pose.position.y
             )
         else:
             self._goal_point = None
@@ -959,6 +992,11 @@ class Controller(Component):
             None  # robot current state - to be updated from odom
         )
         self.plan: Optional[Path] = None  # robot plan (global path)
+
+        # The plan is tracked against the robot state, which is brought into
+        # the world frame, so the two have to agree. The plan carries its own
+        # frame in its messages, so nothing has to be configured
+        self.transform_inputs_to(TopicsKeys.GLOBAL_PLAN, self.config.frames.world)
 
         # INIT PATH CONTROLLER
         self._robot = Robot(
@@ -1237,6 +1275,9 @@ class Controller(Component):
         # Note: This will automatically end the vision target tracking action if it is ongoing
         self.config._mode = ControllerMode.PATH_FOLLOWER
 
+        if not self._plan_tf_available():
+            goal_handle.abort()
+            return result
         self._path_controller.set_path(self.plan)  # type: ignore
 
         self._reached_end: bool = False

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union, List, Dict, Any
 import time
-from attrs import define, field
+from attrs import define, field, fields
 from queue import Queue, Empty
 import numpy as np
 
@@ -13,7 +13,7 @@ from geometry_msgs.msg import PoseStamped
 
 # KOMPASS
 from kompass_core.models import Robot, RobotState
-from ros_sugar.io import LaserScanData, PointCloudData
+from ros_sugar.io import LaserScanData, PointCloudCallback, PointCloudData
 from kompass_core.utils.geometry import from_euler_to_quaternion
 from kompass_core.control import (
     ControlClasses,
@@ -812,18 +812,22 @@ class Controller(Component):
         """Transform listener from the proximity sensor frame to the robot body.
 
         Resolved from the sensor data's own frame, so it is None until the
-        first message arrives.
+        first message arrives. This is the mount pose the core needs to place a
+        laser scan; it is not used to transform the data here.
         """
         return self.input_tf_listener(
             TopicsKeys.SPATIAL_SENSOR, self.config.frames.robot_base, static_tf=True
         )
 
     def _update_sensor_data(self) -> None:
-        """Update sensor data from the sensor callback"""
+        """Update sensor data from the sensor callback.
+
+        A laser scan is left in the sensor frame; a point cloud is delivered in
+        the world frame by its callback. See ``init_variables`` for why.
+        """
         if self.direct_sensor:
             self.local_map = None
             sensor_callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)
-            # The sensor->body transform is applied by the callback itself
             self.sensor_data = (
                 sensor_callback.get_output() if sensor_callback else None
             )
@@ -1021,43 +1025,107 @@ class Controller(Component):
         # Command queue to send controller command list to the robot
         self._cmds_queue: Queue = Queue()
 
-        if self.direct_sensor:
-            # Sensor data is used in the robot body frame. Its own frame comes
-            # from the incoming messages, whatever the sensor type
-            self.transform_inputs_to(
-                TopicsKeys.SPATIAL_SENSOR,
-                self.config.frames.robot_base,
-                static_tf=True,
-            )
+        self.sensor_data: Optional[Union[LaserScanData, PointCloudData]] = None
 
-            self.sensor_data: Optional[Union[LaserScanData, PointCloudData]] = None
+        # Obstacle inputs are handed to the core in the frame it expects for
+        # that input type, and the core does the rest:
+        #
+        #  - a laser scan stays in the **sensor frame**. The core lifts it into
+        #    the world itself, from the mount pose it is given at construction
+        #    and the robot's world pose. So no transform is requested here.
+        #  - cartesian obstacles, whether a decoded point cloud or local map
+        #    cells, are handed over in the **world frame** and used untouched.
+        #
+        # Both are registered regardless of `use_direct_sensor`, since it can be
+        # flipped at runtime and only the subscribed input ever resolves one.
+        if isinstance(
+            self.get_callback(TopicsKeys.SPATIAL_SENSOR), PointCloudCallback
+        ):
+            self.transform_inputs_to(
+                TopicsKeys.SPATIAL_SENSOR, self.config.frames.world
+            )
+        self.transform_inputs_to(TopicsKeys.LOCAL_MAP, self.config.frames.world)
 
         self._path_controller: Optional[ControllerType] = None
+        # The sensor mount pose is only knowable once a scan has arrived, and
+        # the core takes it at construction -> see _apply_sensor_mount_pose
+        self._sensor_mount_pose_set: bool = False
 
         if self.config._mode == ControllerMode.PATH_FOLLOWER:
-            config_kwargs = {}
-            sensor_tf = self._sensor_tf_listener if self.direct_sensor else None
-            if sensor_tf and sensor_tf.got_transform:
-                config_kwargs["proximity_sensor_position_to_robot"] = (
-                    sensor_tf.translation
-                )
-                config_kwargs["proximity_sensor_rotation_to_robot"] = (
-                    sensor_tf.rotation
-                )
-                config_kwargs["control_time_step"] = self.config.control_time_step
-            # Get default controller configuration and update it from user defined config
-            _controller_config = self._configure_algorithm(
-                ControlConfigClasses[self.algorithm](**config_kwargs)
-            )
+            self._build_path_controller()
 
-            self._path_controller = ControlClasses[self.algorithm](
-                robot=self._robot,
-                config=_controller_config,
-                ctrl_limits=self._robot_ctr_limits,
-                config_file=self._config_file,
-                config_root_name=f"{self.node_name}.{self.config.algorithm}",
-                control_time_step=self.config.control_time_step,
+    def _build_path_controller(self, **config_kwargs) -> None:
+        """(Re)build the core algorithm object.
+
+        :param config_kwargs: Algorithm config overrides, used to pass the
+            sensor mount pose once it is known
+        """
+        config_class = ControlConfigClasses[self.algorithm]
+        # The config classes do not share a common set of fields: only DWA and
+        # PurePursuit carry a proximity sensor pose, so anything the selected
+        # one does not declare is dropped rather than raising
+        accepted = {attribute.name.lstrip("_") for attribute in fields(config_class)}
+        dropped = set(config_kwargs) - accepted
+        if dropped:
+            self.get_logger().debug(
+                f"'{self.algorithm}' config takes no {sorted(dropped)} -> ignored"
             )
+        # Get default controller configuration and update it from user defined config
+        _controller_config = self._configure_algorithm(
+            config_class(**{
+                name: value
+                for name, value in config_kwargs.items()
+                if name in accepted
+            })
+        )
+
+        self._path_controller = ControlClasses[self.algorithm](
+            robot=self._robot,
+            config=_controller_config,
+            ctrl_limits=self._robot_ctr_limits,
+            config_file=self._config_file,
+            config_root_name=f"{self.node_name}.{self.config.algorithm}",
+            control_time_step=self.config.control_time_step,
+        )
+
+    def _apply_sensor_mount_pose(self) -> None:
+        """Hand the sensor-to-body mount pose to the core, once it is known.
+
+        Only a laser scan needs it: it reaches the core in the sensor frame, so
+        the core cannot place it without the mount pose. The pose comes from the
+        scan's own ``frame_id``, so it cannot be resolved before the first
+        message, and the core takes it at construction -- hence the one-time
+        rebuild here rather than at ``init_variables`` time.
+        """
+        if self._sensor_mount_pose_set or self._path_controller is None:
+            return
+
+        if not self.direct_sensor or not isinstance(self.sensor_data, LaserScanData):
+            # Cartesian obstacles arrive in the world frame; no mount pose to apply
+            self._sensor_mount_pose_set = True
+            return
+
+        sensor_tf = self._sensor_tf_listener
+        if not sensor_tf or not sensor_tf.got_transform:
+            self.get_logger().warning(
+                "Waiting for the transform from the laser scan frame to "
+                f"'{self.config.frames.robot_base}' to place the scan...",
+                throttle_duration_sec=5.0,
+            )
+            return
+
+        self._build_path_controller(
+            proximity_sensor_position_to_robot=sensor_tf.translation,
+            proximity_sensor_rotation_to_robot=sensor_tf.rotation,
+        )
+        self._sensor_mount_pose_set = True
+        # The rebuild dropped the path the previous object was tracking
+        if self.plan is not None:
+            self._path_controller.set_path(global_path=self.plan)
+        self.get_logger().info(
+            "Applied the laser scan mount pose to the "
+            f"'{self.algorithm}' controller"
+        )
 
     def _stop_robot(self):
         """
@@ -1135,6 +1203,7 @@ class Controller(Component):
 
         self._update_state(block=True)
         self._update_sensor_data()
+        self._apply_sensor_mount_pose()
 
         if not self.robot_state:
             self.get_logger().warning(
@@ -1243,18 +1312,10 @@ class Controller(Component):
                 goal_handle.abort()
                 return result
 
-            # Get default controller configuration and update it from user defined config
-            _controller_config = self._configure_algorithm(
-                ControlConfigClasses[self.algorithm]()
-            )
-
-            self._path_controller = ControlClasses[self.algorithm](
-                robot=self._robot,
-                config=_controller_config,
-                ctrl_limits=self._robot_ctr_limits,
-                config_file=self._config_file,
-                config_root_name=f"{self.node_name}.{self.config.algorithm}",
-            )
+            # A different algorithm means a fresh object, so the mount pose has
+            # to be handed to it again on the next control step
+            self._sensor_mount_pose_set = False
+            self._build_path_controller()
             self.get_logger().info(f"Initialized '{self.algorithm}' controller")
         else:
             self.get_logger().warning(

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -644,6 +644,10 @@ class Controller(Component):
         :param value: Use direct sensor data flag
         :type value: bool
         """
+        # Reset sensor mount pose if the direct sensor flag is changed
+        if value != self.config.use_direct_sensor:
+            self._sensor_mount_pose_set = False
+
         # Note: Only DWA takes local map
         if (
             self.algorithm
@@ -657,7 +661,6 @@ class Controller(Component):
             get_logger(self.node_name).warning(
                 f"Cannot use Local Map with {self.algorithm} - Setting 'direct_sensor' to True"
             )
-            self._sensor_mount_pose_set = False
             self.config.use_direct_sensor = True
             return
         self.config.use_direct_sensor = value

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -831,10 +831,8 @@ class Controller(Component):
     def _update_sensor_data(self) -> bool:
         """Update sensor data from the sensor callback.
 
-        A laser scan is left in the sensor frame, since the core places it from
-        the mount pose. Cartesian obstacles -- a point cloud or local map cells
-        -- are asked for in the world frame, and dropped rather than handed over
-        unconverted if they cannot be put there.
+        A laser scan is left in the sensor frame. Cartesian obstacles, a point
+        cloud or local map cells are asked for in the world frame.
 
         :return: Whether the obstacle input could be delivered in the frame the
             core expects. False leaves the controller without obstacles for this
@@ -997,8 +995,7 @@ class Controller(Component):
     def _read_plan(self) -> Optional[Path]:
         """Read the global plan, in the world frame the core tracks against.
 
-        The single place a plan is fetched, so every consumer gets the same
-        guarantee: either the plan is in the world frame, or there is no plan.
+        The plan is either in the world frame, or there is no plan.
 
         :return: The plan in the world frame, or None if there is none or it
             cannot be brought there yet
@@ -1039,9 +1036,8 @@ class Controller(Component):
     def _install_plan(self, plan: Path) -> bool:
         """Hand a world-frame plan to the core and take the goal point from it.
 
-        Shared by the arrival hook and the retry in ``_path_control`` so the
-        two cannot drift: a plan that reaches the core must always bring its
-        goal point with it, or ``reached_point`` judges against a stale one.
+        Shared by the arrival hook and the retry in ``_path_control``.
+        A plan that reaches the core must always bring its goal point with it.
 
         :param plan: Global plan, already in the world frame
         :type plan: Path
@@ -1063,8 +1059,8 @@ class Controller(Component):
         if self._path_controller is None:
             return False
 
-        # Handed over whatever its length: the core clears its own current path
-        # when given fewer than two poses, and that is the only way a stale
+        # NOTE: Handed over whatever its length. The core clears its own current
+        # path when given fewer than two poses, and that is the only way a stale
         # path gets dropped. Skipping the call leaves the robot tracking it
         self._path_controller.set_path(global_path=plan)
         return bool(self._path_controller.path)
@@ -1081,7 +1077,7 @@ class Controller(Component):
         )
         self.plan: Optional[Path] = None  # robot plan (global path)
 
-        # The plan is tracked against the robot state, which is brought into
+        # NOTE: The plan is tracked against the robot state, which is brought into
         # the world frame, so the two have to agree. The plan carries its own
         # frame in its messages, so nothing has to be configured
         self.transform_inputs_to(TopicsKeys.GLOBAL_PLAN, self.config.frames.world)
@@ -1102,8 +1098,7 @@ class Controller(Component):
         self._ori_error: float = 0.0
 
         # Vision tracking lifecycle helper (owns _vision_controller, detections,
-        # depth image and tracked-target state). Always instantiated; dormant
-        # in path follower mode.
+        # depth image and tracked-target state). Dormant in path follower mode.
         self._vision_follower = VisionFollower(self)
 
         # Command queue to send controller command list to the robot
@@ -1111,7 +1106,7 @@ class Controller(Component):
 
         self.sensor_data: Optional[Union[LaserScanData, PointCloudData]] = None
 
-        # Obstacle inputs are handed to the core in the frame it expects for
+        # NOTE: Obstacle inputs are handed to the core in the frame it expects for
         # that input type, and the core does the rest:
         #
         #  - a laser scan stays in the **sensor frame**. The core lifts it into

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -958,7 +958,10 @@ class Controller(Component):
         """
         plan_callback = self.get_callback(TopicsKeys.GLOBAL_PLAN)
         if not plan_callback:
-            return False
+            # No subscription to ask about the frame. That is the same
+            # not-knowing as a plan without a frame_id, so it is taken at face
+            # value rather than treated as a plan in the wrong frame
+            return True
         plan_frame = plan_callback.frame_id
         # A plan with no frame_id is taken at face value, matching how a
         # headerless robot location message is handled

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -1042,18 +1042,29 @@ class Controller(Component):
 
         :param plan: Global plan, already in the world frame
         :type plan: Path
+
+        :return: Whether the core came away with a path to track
+        :rtype: bool
         """
-        if len(plan.poses) > 1 and self._path_controller is not None:
-            self.plan = plan
-            self._reached_end = False
-            self._path_controller.set_path(global_path=plan)
+        self.plan = plan
+        self._reached_end = False
+
+        if len(plan.poses) > 1:
             self._goal_point = RobotState(
                 x=plan.poses[-1].pose.position.x, y=plan.poses[-1].pose.position.y
             )
-            return True
         else:
+            # Fewer than two poses is "no goal"
             self._goal_point = None
+
+        if self._path_controller is None:
             return False
+
+        # Handed over whatever its length: the core clears its own current path
+        # when given fewer than two poses, and that is the only way a stale
+        # path gets dropped. Skipping the call leaves the robot tracking it
+        self._path_controller.set_path(global_path=plan)
+        return bool(self._path_controller.path)
 
     def init_variables(self):
         """

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -1031,17 +1031,29 @@ class Controller(Component):
                 throttle_duration_sec=5.0,
             )
             return
-        plan = output
-        self.plan = plan
-        self._reached_end = False
-        if self._path_controller:
+        self._install_plan(output)
+
+    def _install_plan(self, plan: Path) -> bool:
+        """Hand a world-frame plan to the core and take the goal point from it.
+
+        Shared by the arrival hook and the retry in ``_path_control`` so the
+        two cannot drift: a plan that reaches the core must always bring its
+        goal point with it, or ``reached_point`` judges against a stale one.
+
+        :param plan: Global plan, already in the world frame
+        :type plan: Path
+        """
+        if len(plan.poses) > 1 and self._path_controller is not None:
+            self.plan = plan
+            self._reached_end = False
             self._path_controller.set_path(global_path=plan)
-        if len(plan.poses) > 1:
             self._goal_point = RobotState(
                 x=plan.poses[-1].pose.position.x, y=plan.poses[-1].pose.position.y
             )
+            return True
         else:
             self._goal_point = None
+            return False
 
     def init_variables(self):
         """
@@ -1257,22 +1269,22 @@ class Controller(Component):
             return PathControlStatus.IDLE
 
         if not self._path_controller.path:
-            # No global path -> nothing to control toward
-            return PathControlStatus.IDLE
+            plan = self._read_plan()
+            # No plan is set to the controller -> read plan from callback
+            if (plan is None) or (not self._install_plan(plan)):
+                # Plan is not available or rejected by the core, which needs at least two poses
+                return PathControlStatus.IDLE
 
         self._update_state(block=True)
         obstacles_deliverable = self._update_sensor_data()
         self._apply_sensor_mount_pose()
 
-        if not obstacles_deliverable:
-            # Obstacles exist but could not be put in the frame the core reads
-            return PathControlStatus.WAITING_INPUTS
-
-        if not self.robot_state:
+        if not obstacles_deliverable or not self.robot_state:
             self.get_logger().warning(
-                f"Robot state unavailable after {self.config.topic_subscription_timeout}s -> skipping control step",
-                throttle_duration_sec=5.0,
-            )
+                            f"State or sensor data unavailable after {self.config.topic_subscription_timeout}s -> skipping control step",
+                            throttle_duration_sec=5.0,
+                        )
+            # Obstacles exist but could not be put in the frame the core reads
             return PathControlStatus.WAITING_INPUTS
 
         ranges = None

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -13,7 +13,12 @@ from geometry_msgs.msg import PoseStamped
 
 # KOMPASS
 from kompass_core.models import Robot, RobotState
-from ros_sugar.io import LaserScanData, PointCloudCallback, PointCloudData
+from ros_sugar.io import (
+    LaserScanData,
+    PointCloudCallback,
+    LaserScanCallback,
+    PointCloudData,
+)
 from kompass_core.utils.geometry import from_euler_to_quaternion
 from kompass_core.control import (
     ControlClasses,
@@ -892,7 +897,11 @@ class Controller(Component):
                 timeout += step
                 time.sleep(step)
 
-            if state_callback and state_callback.got_msg and not state_callback.frame_id:
+            if (
+                state_callback
+                and state_callback.got_msg
+                and not state_callback.frame_id
+            ):
                 # A bare Pose carries no header, so there is no frame to look up
                 # and nothing to transform: take the data as it arrived.
                 self.get_logger().warning(
@@ -1038,9 +1047,7 @@ class Controller(Component):
         #
         # Both are registered regardless of `use_direct_sensor`, since it can be
         # flipped at runtime and only the subscribed input ever resolves one.
-        if isinstance(
-            self.get_callback(TopicsKeys.SPATIAL_SENSOR), PointCloudCallback
-        ):
+        if isinstance(self.get_callback(TopicsKeys.SPATIAL_SENSOR), PointCloudCallback):
             self.transform_inputs_to(
                 TopicsKeys.SPATIAL_SENSOR, self.config.frames.world
             )

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -657,6 +657,7 @@ class Controller(Component):
             get_logger(self.node_name).warning(
                 f"Cannot use Local Map with {self.algorithm} - Setting 'direct_sensor' to True"
             )
+            self._sensor_mount_pose_set = False
             self.config.use_direct_sensor = True
             return
         self.config.use_direct_sensor = value

--- a/kompass/kompass/components/controller.py
+++ b/kompass/kompass/components/controller.py
@@ -833,9 +833,7 @@ class Controller(Component):
         if self.direct_sensor:
             self.local_map = None
             sensor_callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR)
-            self.sensor_data = (
-                sensor_callback.get_output() if sensor_callback else None
-            )
+            self.sensor_data = sensor_callback.get_output() if sensor_callback else None
         else:
             self.sensor_data = None
             map_callback = self.get_callback(TopicsKeys.LOCAL_MAP)
@@ -1068,9 +1066,7 @@ class Controller(Component):
             sensor mount pose once it is known
         """
         config_class = ControlConfigClasses[self.algorithm]
-        # The config classes do not share a common set of fields: only DWA and
-        # PurePursuit carry a proximity sensor pose, so anything the selected
-        # one does not declare is dropped rather than raising
+        # Check for acceptance since the config classes do not all share the same common set of fields
         accepted = {attribute.name.lstrip("_") for attribute in fields(config_class)}
         dropped = set(config_kwargs) - accepted
         if dropped:
@@ -1078,13 +1074,13 @@ class Controller(Component):
                 f"'{self.algorithm}' config takes no {sorted(dropped)} -> ignored"
             )
         # Get default controller configuration and update it from user defined config
-        _controller_config = self._configure_algorithm(
-            config_class(**{
-                name: value
-                for name, value in config_kwargs.items()
-                if name in accepted
-            })
-        )
+        _controller_config = self._configure_algorithm(config_class())
+
+        # Update with given config arguments, if any.
+        # This is used to pass the sensor mount pose once it is known.
+        for name, value in config_kwargs.items():
+            if name in accepted:
+                setattr(_controller_config, name, value)
 
         self._path_controller = ControlClasses[self.algorithm](
             robot=self._robot,
@@ -1107,8 +1103,10 @@ class Controller(Component):
         if self._sensor_mount_pose_set or self._path_controller is None:
             return
 
-        if not self.direct_sensor or not isinstance(self.sensor_data, LaserScanData):
-            # Cartesian obstacles arrive in the world frame; no mount pose to apply
+        if not self.direct_sensor or not isinstance(
+            self.get_callback(TopicsKeys.SPATIAL_SENSOR), LaserScanCallback
+        ):
+            # If a map is being used or direct sensor data is not laserscan, the core does not need a mount pose and can be built once at init time
             self._sensor_mount_pose_set = True
             return
 
@@ -1129,10 +1127,6 @@ class Controller(Component):
         # The rebuild dropped the path the previous object was tracking
         if self.plan is not None:
             self._path_controller.set_path(global_path=self.plan)
-        self.get_logger().info(
-            "Applied the laser scan mount pose to the "
-            f"'{self.algorithm}' controller"
-        )
 
     def _stop_robot(self):
         """

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -270,12 +270,9 @@ class DriveManager(Component):
         # Emergency checker gets initialized on activation to get the sensor transformation
         self._emergency_checker = None
 
-        # Every proximity sensor is handled in the robot body frame. Each one
-        # carries its own frame in its messages, so several sensors mounted in
-        # different places work without configuring any of them
-        self.transform_inputs_to(
-            TopicsKeys.SPATIAL_SENSOR, self.config.frames.robot_base, static_tf=True
-        )
+        # NOTE: proximity sensor data transformation is deliberately NOT set to the callback here.
+        # CriticalZoneChecker takes its input in the sensor frame and applies
+        # the sensor->body transform itself (it is handed at construction),
 
         self._attach_callbacks_and_processors()
 
@@ -401,18 +398,15 @@ class DriveManager(Component):
         for idx in range(num_sensors):
             callback = self.get_callback(TopicsKeys.SPATIAL_SENSOR, idx)
             if isinstance(callback, LaserScanCallback):
-                # The sensor->body transform is applied by the callback itself
+                # Left in the sensor frame: CriticalZoneChecker transforms it
                 self.sensor_data: Optional[LaserScanData] = callback.get_output()
                 break
             elif isinstance(callback, PointCloudCallback):
                 self.__pc_callback = callback
+                # Raw sensor-frame buffer, undecoded. The height band and the
+                # sensor->body transform are both applied by the checker
                 self.sensor_data: Optional[PointCloudData] = (
-                    self.__pc_callback.get_output(
-                        get_2d=True,
-                        min_z=0.0,
-                        max_z=self.robot_height,
-                        discard_underground=True,
-                    )
+                    self.__pc_callback.get_output()
                 )
                 break
         # If laserscan is not available and safety_stop is enabled -> raise an emergency stop flog to block publishing
@@ -1178,6 +1172,13 @@ class DriveManager(Component):
         robot_shape = self.robot_geometry_type
         robot_dimensions = self.robot.geometry_params
 
+        # The checker gates point heights on the raw sensor-frame z, before it
+        # applies the sensor->body transform, so the body-frame band we want
+        # (ground .. robot top) has to be shifted down by the sensor height
+        sensor_height = float(sensor_tf.translation[2])
+        min_height = -sensor_height
+        max_height = self.robot_height - sensor_height
+
         # Get laserscan data to initialize the GPU based checker
         while not self.sensor_data:
             self.get_logger().info(
@@ -1235,8 +1236,8 @@ class DriveManager(Component):
                     critical_angle=self.config.critical_zone_angle,
                     critical_distance=self.config.critical_zone_distance,
                     slowdown_distance=self.config.slowdown_zone_distance,
-                    max_height=self.robot_height,
-                    min_height=-self.robot_height,
+                    max_height=max_height,
+                    min_height=min_height,
                     range_max=3 * self.config.slowdown_zone_distance,
                     **kwargs,
                 )
@@ -1279,8 +1280,8 @@ class DriveManager(Component):
             critical_angle=self.config.critical_zone_angle,
             critical_distance=self.config.critical_zone_distance,
             slowdown_distance=self.config.slowdown_zone_distance,
-            max_height=self.robot_height,
-            min_height=-self.robot_height,
+            max_height=max_height,
+            min_height=min_height,
             range_max=3 * self.config.slowdown_zone_distance,
             **kwargs,
         )

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -440,26 +440,39 @@ class DriveManager(Component):
             if self._emergency_checker:
                 self._update_state()
                 # Check emergency stop from Lidar in the direction of the command
-                if isinstance(self.sensor_data, LaserScanData):
-                    self.slow_down_factor["scan_data"] = self._emergency_checker.check(
-                        ranges=self.sensor_data.ranges,
-                        forward=(vx_out >= 0.0),
+                try:
+                    if isinstance(self.sensor_data, LaserScanData):
+                        self.slow_down_factor["scan_data"] = (
+                            self._emergency_checker.check(
+                                ranges=self.sensor_data.ranges,
+                                forward=(vx_out >= 0.0),
+                            )
+                        )
+                    elif isinstance(self.sensor_data, PointCloudData):
+                        self.slow_down_factor["scan_data"] = (
+                            self._emergency_checker.check(
+                                data=self.sensor_data.data,
+                                point_step=self.sensor_data.point_step,
+                                row_step=self.sensor_data.row_step,
+                                height=self.sensor_data.height,
+                                width=self.sensor_data.width,
+                                x_offset=self.sensor_data.x_offset,
+                                y_offset=self.sensor_data.y_offset,
+                                z_offset=self.sensor_data.z_offset,
+                                forward=(vx_out >= 0.0),
+                            )
+                        )
+                        self.get_logger().debug(
+                            f"PointCloud emergency check forward={(vx_out >= 0.0)} returned {self.slow_down_factor['scan_data']}"
+                        )
+                except Exception as e:
+                    # A checker that cannot evaluate the sensor data (e.g.
+                    # malformed cloud metadata) must stop the robot and keep the
+                    # component alive
+                    self.get_logger().error(
+                        f"CriticalZoneChecker failed on incoming sensor data: {e} -> Triggering emergency stop"
                     )
-                elif isinstance(self.sensor_data, PointCloudData):
-                    self.slow_down_factor["scan_data"] = self._emergency_checker.check(
-                        data=self.sensor_data.data,
-                        point_step=self.sensor_data.point_step,
-                        row_step=self.sensor_data.row_step,
-                        height=self.sensor_data.height,
-                        width=self.sensor_data.width,
-                        x_offset=self.sensor_data.x_offset,
-                        y_offset=self.sensor_data.y_offset,
-                        z_offset=self.sensor_data.z_offset,
-                        forward=(vx_out >= 0.0),
-                    )
-                    self.get_logger().debug(
-                        f"PointCloud emergency check forward={(vx_out >= 0.0)} returned {self.slow_down_factor['scan_data']}"
-                    )
+                    self.slow_down_factor["scan_data"] = 0.0
             slowdown_val: float = min(self.slow_down_factor.values())
         else:
             slowdown_val = slowdown_factor
@@ -566,23 +579,30 @@ class DriveManager(Component):
             # Check if max_distance forward is clear
             self._update_state()
             slowdown_factor = 1.0
-            if isinstance(self.sensor_data, LaserScanData):
-                slowdown_factor = self._emergency_checker.check(
-                    ranges=self.sensor_data.ranges,
-                    forward=True,
+            try:
+                if isinstance(self.sensor_data, LaserScanData):
+                    slowdown_factor = self._emergency_checker.check(
+                        ranges=self.sensor_data.ranges,
+                        forward=True,
+                    )
+                elif isinstance(self.sensor_data, PointCloudData):
+                    slowdown_factor = self._emergency_checker.check(
+                        data=self.sensor_data.data,
+                        point_step=self.sensor_data.point_step,
+                        row_step=self.sensor_data.row_step,
+                        height=self.sensor_data.height,
+                        width=self.sensor_data.width,
+                        x_offset=self.sensor_data.x_offset,
+                        y_offset=self.sensor_data.y_offset,
+                        z_offset=self.sensor_data.z_offset,
+                        forward=True,
+                    )
+            except Exception as e:
+                # Cannot evaluate the data -> treat the direction as blocked
+                self.get_logger().error(
+                    f"CriticalZoneChecker failed on incoming sensor data: {e} -> Treating direction as blocked"
                 )
-            elif isinstance(self.sensor_data, PointCloudData):
-                slowdown_factor = self._emergency_checker.check(
-                    data=self.sensor_data.data,
-                    point_step=self.sensor_data.point_step,
-                    row_step=self.sensor_data.row_step,
-                    height=self.sensor_data.height,
-                    width=self.sensor_data.width,
-                    x_offset=self.sensor_data.x_offset,
-                    y_offset=self.sensor_data.y_offset,
-                    z_offset=self.sensor_data.z_offset,
-                    forward=True,
-                )
+                slowdown_factor = 0.0
             if slowdown_factor == 0.0:
                 unblocking = False
             else:
@@ -639,23 +659,30 @@ class DriveManager(Component):
             # Check if max_distance behind the robot is clear
             self._update_state()
             slowdown_factor = 1.0
-            if isinstance(self.sensor_data, LaserScanData):
-                slowdown_factor = self._emergency_checker.check(
-                    ranges=self.sensor_data.ranges,
-                    forward=False,
+            try:
+                if isinstance(self.sensor_data, LaserScanData):
+                    slowdown_factor = self._emergency_checker.check(
+                        ranges=self.sensor_data.ranges,
+                        forward=False,
+                    )
+                elif isinstance(self.sensor_data, PointCloudData):
+                    slowdown_factor = self._emergency_checker.check(
+                        data=self.sensor_data.data,
+                        point_step=self.sensor_data.point_step,
+                        row_step=self.sensor_data.row_step,
+                        height=self.sensor_data.height,
+                        width=self.sensor_data.width,
+                        x_offset=self.sensor_data.x_offset,
+                        y_offset=self.sensor_data.y_offset,
+                        z_offset=self.sensor_data.z_offset,
+                        forward=False,
+                    )
+            except Exception as e:
+                # Cannot evaluate the data -> treat the direction as blocked
+                self.get_logger().error(
+                    f"CriticalZoneChecker failed on incoming sensor data: {e} -> Treating direction as blocked"
                 )
-            elif isinstance(self.sensor_data, PointCloudData):
-                slowdown_factor = self._emergency_checker.check(
-                    data=self.sensor_data.data,
-                    point_step=self.sensor_data.point_step,
-                    row_step=self.sensor_data.row_step,
-                    height=self.sensor_data.height,
-                    width=self.sensor_data.width,
-                    x_offset=self.sensor_data.x_offset,
-                    y_offset=self.sensor_data.y_offset,
-                    z_offset=self.sensor_data.z_offset,
-                    forward=False,
-                )
+                slowdown_factor = 0.0
             if slowdown_factor == 0.0:
                 unblocking = False
             else:

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -753,42 +753,50 @@ class DriveManager(Component):
         while unblocking and traveled_radius < max_rotation:
             self._update_state()
             slowdown_factor = 1.0
-            if isinstance(self.sensor_data, LaserScanData):
-                slowdown_factor = min(
-                    self._emergency_checker.check(
-                        ranges=self.sensor_data.ranges,
-                        forward=True,
-                    ),
-                    self._emergency_checker.check(
-                        ranges=self.sensor_data.ranges,
-                        forward=False,
-                    ),
+            try:
+                if isinstance(self.sensor_data, LaserScanData):
+                    slowdown_factor = min(
+                        self._emergency_checker.check(
+                            ranges=self.sensor_data.ranges,
+                            forward=True,
+                        ),
+                        self._emergency_checker.check(
+                            ranges=self.sensor_data.ranges,
+                            forward=False,
+                        ),
+                    )
+                elif isinstance(self.sensor_data, PointCloudData):
+                    slowdown_factor = min(
+                        self._emergency_checker.check(
+                            data=self.sensor_data.data,
+                            point_step=self.sensor_data.point_step,
+                            row_step=self.sensor_data.row_step,
+                            height=self.sensor_data.height,
+                            width=self.sensor_data.width,
+                            x_offset=self.sensor_data.x_offset,
+                            y_offset=self.sensor_data.y_offset,
+                            z_offset=self.sensor_data.z_offset,
+                            forward=True,
+                        ),
+                        self._emergency_checker.check(
+                            data=self.sensor_data.data,
+                            point_step=self.sensor_data.point_step,
+                            row_step=self.sensor_data.row_step,
+                            height=self.sensor_data.height,
+                            width=self.sensor_data.width,
+                            x_offset=self.sensor_data.x_offset,
+                            y_offset=self.sensor_data.y_offset,
+                            z_offset=self.sensor_data.z_offset,
+                            forward=False,
+                        ),
+                    )
+            except Exception as e:
+                # Cannot evaluate the data mid-rotation -> treat the robot
+                # surroundings as blocked and end the maneuver
+                self.get_logger().error(
+                    f"CriticalZoneChecker failed on incoming sensor data: {e} -> Treating rotation as blocked"
                 )
-            elif isinstance(self.sensor_data, PointCloudData):
-                slowdown_factor = min(
-                    self._emergency_checker.check(
-                        data=self.sensor_data.data,
-                        point_step=self.sensor_data.point_step,
-                        row_step=self.sensor_data.row_step,
-                        height=self.sensor_data.height,
-                        width=self.sensor_data.width,
-                        x_offset=self.sensor_data.x_offset,
-                        y_offset=self.sensor_data.y_offset,
-                        z_offset=self.sensor_data.z_offset,
-                        forward=True,
-                    ),
-                    self._emergency_checker.check(
-                        data=self.sensor_data.data,
-                        point_step=self.sensor_data.point_step,
-                        row_step=self.sensor_data.row_step,
-                        height=self.sensor_data.height,
-                        width=self.sensor_data.width,
-                        x_offset=self.sensor_data.x_offset,
-                        y_offset=self.sensor_data.y_offset,
-                        z_offset=self.sensor_data.z_offset,
-                        forward=False,
-                    ),
-                )
+                slowdown_factor = 0.0
             if slowdown_factor == 0.0:
                 unblocking = False
             else:

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -1269,6 +1269,8 @@ class DriveManager(Component):
                 self.get_logger().warning(
                     "GPU use is enabled but CriticalZoneCheckerGPU implementation is not found -> Using CPU implementation instead"
                 )
+                # GPU-only ctor param; the CPU checker does not accept it
+                kwargs.pop("cloud_field_type", None)
 
         from kompass_cpp.utils import CriticalZoneChecker
 

--- a/kompass/kompass/components/drive_manager.py
+++ b/kompass/kompass/components/drive_manager.py
@@ -416,7 +416,7 @@ class DriveManager(Component):
             and not self.config.use_without_scan_sensor
         ):
             self.get_logger().warning(
-                "LaserScan data is not available -> disabling command publish to robot. To use the DriveManager without safety stop set 'disable_safety_stop' to 'True'",
+                "Proximity sensor data is not available -> blocking command publishing to robot.",
                 once=True,
             )
             self.slow_down_factor["unavailable_data"] = 0.0
@@ -457,7 +457,7 @@ class DriveManager(Component):
                         z_offset=self.sensor_data.z_offset,
                         forward=(vx_out >= 0.0),
                     )
-                    self.get_logger().info(
+                    self.get_logger().debug(
                         f"PointCloud emergency check forward={(vx_out >= 0.0)} returned {self.slow_down_factor['scan_data']}"
                     )
             slowdown_val: float = min(self.slow_down_factor.values())
@@ -836,7 +836,7 @@ class DriveManager(Component):
         """
         if not self.sensor_data:
             self.get_logger().error(
-                "Scan unavailable - Unblocking functionality requires LaserScan information"
+                "Proximity sensor data unavailable - Unblocking functionality requires LaserScan or PointCloud information"
             )
             return False
 
@@ -1164,7 +1164,7 @@ class DriveManager(Component):
                 self.config.frames.robot_base,
                 static_tf=True,
             )
-            self.get_logger().info("Waiting to get Proximity Sensor TF...", once=True)
+            self.get_logger().info("Checking for Proximity Sensor TF...", once=True)
             time.sleep(1 / self.config.loop_rate)
 
         self.get_logger().info("Got Proximity Sensor TF...")
@@ -1182,7 +1182,7 @@ class DriveManager(Component):
         # Get laserscan data to initialize the GPU based checker
         while not self.sensor_data:
             self.get_logger().info(
-                "Waiting to get laserscan data to initialize CriticalZoneChecker..",
+                "Waiting to get proximity sensor data to initialize CriticalZoneChecker..",
                 once=True,
             )
             self._update_state()

--- a/kompass/kompass/components/map_server.py
+++ b/kompass/kompass/components/map_server.py
@@ -311,7 +311,7 @@ class MapServer(Component):
         occupied_thresh = float(map_metadata["occupied_thresh"])
         free_thresh = float(map_metadata["free_thresh"])
 
-        img = cv2.imread(file_root / Path(image_path), -1)
+        img = cv2.imread(str(file_root / Path(image_path)), -1)
 
         if img is None:
             raise FileNotFoundError(f"No valid map is found at: {image_path}")

--- a/kompass/test/test_path_control.py
+++ b/kompass/test/test_path_control.py
@@ -60,6 +60,8 @@ def make_path_controller_stub(**overrides) -> Controller:
     _set_mangled(c, "lat_dist_error", 0.0)
     _set_mangled(c, "ori_error", 0.0)
     _set_mangled(c, "goal_point", RobotState(x=10.0, y=0.0))
+    # Latch for the one-time rebuild that hands the core the sensor mount pose
+    _set_mangled(c, "sensor_mount_pose_set", False)
 
     c.robot_state = RobotState(x=0.0, y=0.0, yaw=0.0)
     c.plan = None


### PR DESCRIPTION
Aligns the frames Kompass components hand to kompass-core with the frames the core actually expects. An audit of Controller / DriveManager / Mapper against the core turned up several mismatches where data was transformed twice, not at all, or interpreted in two different frames by two consumers of the same argument.

The core-side half of this fix (an explicit per-input-type frame contract, plus a `sensorTfWorld()` helper that fixes a reversed transform composition) lands in kompass-core separately. This PR makes the ROS components hold up their end.

## The contract

| Input | Frame handed to core | Who transforms |
|---|---|---|
| Laser scan (`ranges`/`angles`) | **sensor frame** | core, from the mount pose it is given at construction + the robot's world pose |
| Point cloud (`points`) | **world frame** | the ROS callback |
| Local map (`local_map`) | **world frame** | the ROS callback |
| Global plan | **world frame** | the ROS callback |
| Proximity sensors → `CriticalZoneChecker` | **sensor frame** | core, from the mount pose it is given at construction |

## Notes / follow-ups not in this PR

- `kompass.callbacks` has a pre-existing import cycle (`callbacks → _external_types → ros → data_types → callbacks`) that only survives because nothing imports it first. Worth untangling.

- The `direct_sensor` and `algorithm` property setters do not rebuild `_path_controller`; flipping them at runtime leaves the algorithm configured for the previous mode.